### PR TITLE
Abstract operators to no longer rely on instance vars

### DIFF
--- a/src/pluto/channel_type.cr
+++ b/src/pluto/channel_type.cr
@@ -1,4 +1,4 @@
-enum Pluto::Channel
+enum Pluto::ChannelType
   Red
   Green
   Blue

--- a/src/pluto/image.cr
+++ b/src/pluto/image.cr
@@ -36,14 +36,15 @@ class Pluto::Image
     )
   end
 
-  def each_channel(&)
+  def each_channel(&) : Nil
     yield @red, Channel::Red
     yield @green, Channel::Green
     yield @blue, Channel::Blue
     yield @alpha, Channel::Alpha
+    nil
   end
 
-  def [](ch : Channel)
+  def [](ch : Channel) : Array(UInt8)
     case ch
     in Channel::Red   then @red
     in Channel::Green then @green
@@ -52,7 +53,7 @@ class Pluto::Image
     end
   end
 
-  def []=(ch : Channel, channel : Array(UInt8))
+  def []=(ch : Channel, channel : Array(UInt8)) : Array(UInt8)
     case ch
     in Channel::Red   then @red = channel
     in Channel::Green then @green = channel

--- a/src/pluto/image.cr
+++ b/src/pluto/image.cr
@@ -15,12 +15,12 @@ class Pluto::Image
   include Operation::HorizontalBlur
   include Operation::VerticalBlur
 
-  property red : Array(UInt8)
-  property green : Array(UInt8)
-  property blue : Array(UInt8)
-  property alpha : Array(UInt8)
-  property width : Int32
-  property height : Int32
+  getter red : Array(UInt8)
+  getter green : Array(UInt8)
+  getter blue : Array(UInt8)
+  getter alpha : Array(UInt8)
+  getter width : Int32
+  getter height : Int32
 
   def initialize(@red, @green, @blue, @alpha, @width, @height)
   end
@@ -34,6 +34,33 @@ class Pluto::Image
       @width,
       @height
     )
+  end
+
+  private def each_channel(&)
+    yield @red, Channel::Red
+    yield @green, Channel::Green
+    yield @blue, Channel::Blue
+    yield @alpha, Channel::Alpha
+  end
+
+  private def [](ch : Channel)
+    case ch
+    when Channel::Red   then @red
+    when Channel::Green then @green
+    when Channel::Blue  then @blue
+    when Channel::Alpha then @alpha
+    else                     raise "Unknown channel #{ch} for Image"
+    end
+  end
+
+  private def []=(ch : Channel, channel : Array(UInt8))
+    case ch
+    when Channel::Red   then @red = channel
+    when Channel::Green then @green = channel
+    when Channel::Blue  then @blue = channel
+    when Channel::Alpha then @alpha = channel
+    else                     raise "Unknown channel #{ch} for Image"
+    end
   end
 
   def size : Int32

--- a/src/pluto/image.cr
+++ b/src/pluto/image.cr
@@ -37,28 +37,28 @@ class Pluto::Image
   end
 
   def each_channel(&) : Nil
-    yield @red, Channel::Red
-    yield @green, Channel::Green
-    yield @blue, Channel::Blue
-    yield @alpha, Channel::Alpha
+    yield @red, ChannelType::Red
+    yield @green, ChannelType::Green
+    yield @blue, ChannelType::Blue
+    yield @alpha, ChannelType::Alpha
     nil
   end
 
-  def [](ch : Channel) : Array(UInt8)
-    case ch
-    in Channel::Red   then @red
-    in Channel::Green then @green
-    in Channel::Blue  then @blue
-    in Channel::Alpha then @alpha
+  def [](channel_type : ChannelType) : Array(UInt8)
+    case channel_type
+    in ChannelType::Red   then @red
+    in ChannelType::Green then @green
+    in ChannelType::Blue  then @blue
+    in ChannelType::Alpha then @alpha
     end
   end
 
-  def []=(ch : Channel, channel : Array(UInt8)) : Array(UInt8)
-    case ch
-    in Channel::Red   then @red = channel
-    in Channel::Green then @green = channel
-    in Channel::Blue  then @blue = channel
-    in Channel::Alpha then @alpha = channel
+  def []=(channel_type : ChannelType, channel : Array(UInt8)) : Array(UInt8)
+    case channel_type
+    in ChannelType::Red   then @red = channel
+    in ChannelType::Green then @green = channel
+    in ChannelType::Blue  then @blue = channel
+    in ChannelType::Alpha then @alpha = channel
     end
   end
 

--- a/src/pluto/image.cr
+++ b/src/pluto/image.cr
@@ -15,12 +15,12 @@ class Pluto::Image
   include Operation::HorizontalBlur
   include Operation::VerticalBlur
 
-  getter red : Array(UInt8)
-  getter green : Array(UInt8)
-  getter blue : Array(UInt8)
-  getter alpha : Array(UInt8)
-  getter width : Int32
-  getter height : Int32
+  property red : Array(UInt8)
+  property green : Array(UInt8)
+  property blue : Array(UInt8)
+  property alpha : Array(UInt8)
+  property width : Int32
+  property height : Int32
 
   def initialize(@red, @green, @blue, @alpha, @width, @height)
   end
@@ -36,30 +36,28 @@ class Pluto::Image
     )
   end
 
-  private def each_channel(&)
+  def each_channel(&)
     yield @red, Channel::Red
     yield @green, Channel::Green
     yield @blue, Channel::Blue
     yield @alpha, Channel::Alpha
   end
 
-  private def [](ch : Channel)
+  def [](ch : Channel)
     case ch
-    when Channel::Red   then @red
-    when Channel::Green then @green
-    when Channel::Blue  then @blue
-    when Channel::Alpha then @alpha
-    else                     raise "Unknown channel #{ch} for Image"
+    in Channel::Red   then @red
+    in Channel::Green then @green
+    in Channel::Blue  then @blue
+    in Channel::Alpha then @alpha
     end
   end
 
-  private def []=(ch : Channel, channel : Array(UInt8))
+  def []=(ch : Channel, channel : Array(UInt8))
     case ch
-    when Channel::Red   then @red = channel
-    when Channel::Green then @green = channel
-    when Channel::Blue  then @blue = channel
-    when Channel::Alpha then @alpha = channel
-    else                     raise "Unknown channel #{ch} for Image"
+    in Channel::Red   then @red = channel
+    in Channel::Green then @green = channel
+    in Channel::Blue  then @blue = channel
+    in Channel::Alpha then @alpha = channel
     end
   end
 

--- a/src/pluto/operation/bilinear_resize.cr
+++ b/src/pluto/operation/bilinear_resize.cr
@@ -4,13 +4,10 @@ module Pluto::Operation::BilinearResize
   end
 
   def bilinear_resize!(width : Int32, height : Int32) : Image
-    channels = {@red, @green, @blue, @alpha}
-    resized_channels = [] of Array(UInt8)
-
     x_ratio = width > 1 ? (@width - 1) / (width - 1) : 0
     y_ratio = height > 1 ? (@height - 1) / (height - 1) : 0
 
-    channels.each do |channel|
+    each_channel do |channel, ch|
       resized_channel = Array.new(width * height) { 0u8 }
 
       height.times do |h|
@@ -53,13 +50,9 @@ module Pluto::Operation::BilinearResize
         end
       end
 
-      resized_channels << resized_channel
+      self[ch] = resized_channel
     end
 
-    @red = resized_channels.unsafe_fetch(0)
-    @green = resized_channels.unsafe_fetch(1)
-    @blue = resized_channels.unsafe_fetch(2)
-    @alpha = resized_channels.unsafe_fetch(3)
     @width = width
     @height = height
 

--- a/src/pluto/operation/bilinear_resize.cr
+++ b/src/pluto/operation/bilinear_resize.cr
@@ -7,7 +7,7 @@ module Pluto::Operation::BilinearResize
     x_ratio = width > 1 ? (@width - 1) / (width - 1) : 0
     y_ratio = height > 1 ? (@height - 1) / (height - 1) : 0
 
-    each_channel do |channel, ch|
+    each_channel do |channel, channel_type|
       resized_channel = Array.new(width * height) { 0u8 }
 
       height.times do |h|
@@ -50,7 +50,7 @@ module Pluto::Operation::BilinearResize
         end
       end
 
-      self[ch] = resized_channel
+      self[channel_type] = resized_channel
     end
 
     @width = width

--- a/src/pluto/operation/brightness.cr
+++ b/src/pluto/operation/brightness.cr
@@ -4,10 +4,10 @@ module Pluto::Operation::Brightness
   end
 
   def brightness!(value : Float64) : Image
-    (@width * @height).times do |index|
-      @red.unsafe_put(index, Math.min(255, (@red.unsafe_fetch(index) * value)).to_u8)
-      @green.unsafe_put(index, Math.min(255, (@green.unsafe_fetch(index) * value)).to_u8)
-      @blue.unsafe_put(index, Math.min(255, (@blue.unsafe_fetch(index) * value)).to_u8)
+    each_channel do |channel|
+      size.times do |index|
+        channel.unsafe_put(index, Math.min(255, (channel.unsafe_fetch(index) * value)).to_u8)
+      end
     end
     self
   end

--- a/src/pluto/operation/channel_swap.cr
+++ b/src/pluto/operation/channel_swap.cr
@@ -1,9 +1,9 @@
 module Pluto::Operation::ChannelSwap
-  def channel_swap(a : Channel, b : Channel) : Image
+  def channel_swap(a : ChannelType, b : ChannelType) : Image
     clone.channel_swap!(a, b)
   end
 
-  def channel_swap!(a : Channel, b : Channel) : Image
+  def channel_swap!(a : ChannelType, b : ChannelType) : Image
     ch_a, ch_b = self[a], self[b]
     self[a] = ch_b
     self[b] = ch_a

--- a/src/pluto/operation/channel_swap.cr
+++ b/src/pluto/operation/channel_swap.cr
@@ -4,20 +4,9 @@ module Pluto::Operation::ChannelSwap
   end
 
   def channel_swap!(a : Channel, b : Channel) : Image
-    case {a, b}
-    when {Channel::Red, Channel::Green}, {Channel::Green, Channel::Red}
-      @red, @green = @green, @red
-    when {Channel::Green, Channel::Blue}, {Channel::Blue, Channel::Green}
-      @green, @blue = @blue, @green
-    when {Channel::Blue, Channel::Red}, {Channel::Red, Channel::Blue}
-      @red, @blue = @blue, @red
-    when {Channel::Alpha, Channel::Red}, {Channel::Red, Channel::Alpha}
-      @alpha, @red = @red, @alpha
-    when {Channel::Alpha, Channel::Green}, {Channel::Green, Channel::Alpha}
-      @alpha, @green = @green, @alpha
-    when {Channel::Alpha, Channel::Blue}, {Channel::Blue, Channel::Alpha}
-      @alpha, @blue = @blue, @alpha
-    end
+    ch_a, ch_b = self[a], self[b]
+    self[a] = ch_b
+    self[b] = ch_a
     self
   end
 end

--- a/src/pluto/operation/contrast.cr
+++ b/src/pluto/operation/contrast.cr
@@ -5,10 +5,10 @@ module Pluto::Operation::Contrast
 
   def contrast!(value : Float64) : Image
     factor = (259 * (value + 255)) / (255 * (259 - value))
-    size.times do |index|
-      @red.unsafe_put(index, Math.min(255, Math.max(0, factor * (@red.unsafe_fetch(index).to_i - 128) + 128)).to_u8)
-      @green.unsafe_put(index, Math.min(255, Math.max(0, factor * (@green.unsafe_fetch(index).to_i - 128) + 128)).to_u8)
-      @blue.unsafe_put(index, Math.min(255, Math.max(0, factor * (@blue.unsafe_fetch(index).to_i - 128) + 128)).to_u8)
+    each_channel do |channel|
+      size.times do |index|
+        channel.unsafe_put(index, Math.min(255, Math.max(0, factor * (channel.unsafe_fetch(index).to_i - 128) + 128)).to_u8)
+      end
     end
     self
   end

--- a/src/pluto/operation/horizontal_blur.cr
+++ b/src/pluto/operation/horizontal_blur.cr
@@ -4,13 +4,11 @@ module Pluto::Operation::HorizontalBlur
   end
 
   def horizontal_blur!(value : Int32) : Image
-    channels = {@red, @green, @blue, @alpha}
-
     buffer = Bytes.new(size, 0)
     multiplier = 1 / (value + value + 1)
 
-    channels.each do |channel|
-      @height.times do |y|
+    each_channel do |channel|
+      height.times do |y|
         c_index : Int32 = y * @width
         l_index : Int32 = c_index
         r_index : Int32 = c_index + value

--- a/src/pluto/operation/vertical_blur.cr
+++ b/src/pluto/operation/vertical_blur.cr
@@ -4,13 +4,11 @@ module Pluto::Operation::VerticalBlur
   end
 
   def vertical_blur!(value : Int32) : Image
-    channels = {@red, @green, @blue, @alpha}
-
     buffer = Bytes.new(size, 0)
     multiplier = 1 / (value + value + 1)
 
-    channels.each do |channel|
-      @width.times do |x|
+    each_channel do |channel|
+      width.times do |x|
         c_index : Int32 = x
         l_index : Int32 = c_index
         r_index : Int32 = c_index + value * @width


### PR DESCRIPTION
I'm interested in information extraction from images at some point (i.e. edge detection, OCR, etc.), and these operations are easier on grey-scale images. I noticed the current set of operations use hard coded references to the `@red`, `@green`, and `@blue` channels whereas a grey-scale image would only have one channel.

This refactor provides some private convenience methods in the `Image` class and removes the hardcoded usage of the channel instance variables. I think without sacrificing performance too (but you might have a better way to measure that than me just rerunning `crystal spec` multiple times :P ).

Sometime in the next week I'm hoping to introduce the `GreyImage` type and conversions between it and the color `Image`, and then I can start adding some more operations from there (if you'll accept them).

Thanks for starting this library!