### PR TITLE
Check error code after calling lib functions

### DIFF
--- a/src/pluto/bindings/lib_jpeg_turbo.cr
+++ b/src/pluto/bindings/lib_jpeg_turbo.cr
@@ -8,6 +8,8 @@ lib LibJPEGTurbo
   fun destroy = tjDestroy(handle : Handle) : LibC::Int
   fun init_compress = tjInitCompress : Handle
   fun init_decompress = tjInitDecompress : Handle
+  fun get_error_code = tjGetErrorCode(handle : Handle) : ErrorCode
+  fun get_error_str = tjGetErrorStr2(handle : Handle) : UInt8*
 
   enum Colorspace
     RGB
@@ -40,5 +42,10 @@ lib LibJPEGTurbo
     Gray
     S440
     S411
+  end
+
+  enum ErrorCode
+    WARNING
+    FATAL
   end
 end

--- a/src/pluto/exception.cr
+++ b/src/pluto/exception.cr
@@ -1,0 +1,8 @@
+class Pluto::Exception < ::Exception
+  getter error_code : LibJPEGTurbo::ErrorCode
+
+  def initialize(handle : LibJPEGTurbo::Handle)
+    super(String.new(LibJPEGTurbo.get_error_str(handle)))
+    @error_code = LibJPEGTurbo.get_error_code(handle)
+  end
+end


### PR DESCRIPTION
I'm not sure in which conditions these might fail, but according to docs they could.
There seems to also be a distinction between warnings that are recoverable 

- TJERR_WARNING: The error was non-fatal and recoverable, but the destination image may still be corrupt.
- TJERR_FATAL: The error was fatal and non-recoverable.

The current implementation will abort in both.

I tried tweaking width and height to invalid values but those do not cause failures of either kinds.

In https://github.com/crystal-lang/crystal-sqlite3 you can see a similar pattern to raise exceptions based on last call return value. There the connection (or handler) is present as an instance variable and hence the `check` is more ergonomic internally and does not need to be defined multiple times.

