### PR TITLE
IO based api for reading jpg and ppm

### DIFF
--- a/spec/pluto/format/jpeg_spec.cr
+++ b/spec/pluto/format/jpeg_spec.cr
@@ -2,6 +2,20 @@ require "../../spec_helper"
 
 describe Pluto::Format::JPEG do
   describe ".from_jpeg" do
+    it "works with IO" do
+      SpecHelper.with_sample("pluto.jpg") do |io|
+        image = Pluto::RGBAImage.from_jpeg(io)
+        Digest::SHA1.hexdigest(image.to_jpeg).should eq "60b7ab88c98807171df33b9242043d1e082b9e1a"
+      end
+    end
+
+    it "works with String" do
+      SpecHelper.with_sample("pluto.jpg") do |io|
+        image = Pluto::RGBAImage.from_jpeg(io.gets_to_end)
+        Digest::SHA1.hexdigest(image.to_jpeg).should eq "60b7ab88c98807171df33b9242043d1e082b9e1a"
+      end
+    end
+
     it "works with RGBAImage" do
       data = SpecHelper.pluto_jpg
       image = Pluto::RGBAImage.from_jpeg(data)

--- a/spec/pluto/format/jpeg_spec.cr
+++ b/spec/pluto/format/jpeg_spec.cr
@@ -3,14 +3,14 @@ require "../../spec_helper"
 describe Pluto::Format::JPEG do
   describe ".from_jpeg" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.jpg")
+      data = SpecHelper.pluto_jpg
       image = Pluto::RGBAImage.from_jpeg(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "60b7ab88c98807171df33b9242043d1e082b9e1a"
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.jpg")
+      data = SpecHelper.pluto_jpg
       image = Pluto::GrayscaleImage.from_jpeg(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "dc96176fe2d46790ac4f3f8efcaef666db06c4f3"
@@ -19,14 +19,14 @@ describe Pluto::Format::JPEG do
 
   describe "#to_jpeg" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.jpg")
+      data = SpecHelper.pluto_jpg
       image = Pluto::RGBAImage.from_jpeg(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "60b7ab88c98807171df33b9242043d1e082b9e1a"
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.jpg")
+      data = SpecHelper.pluto_jpg
       image = Pluto::GrayscaleImage.from_jpeg(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "dc96176fe2d46790ac4f3f8efcaef666db06c4f3"

--- a/spec/pluto/format/ppm_spec.cr
+++ b/spec/pluto/format/ppm_spec.cr
@@ -2,6 +2,20 @@ require "../../spec_helper"
 
 describe Pluto::Format::PPM do
   describe ".from_ppm" do
+    it "works with IO" do
+      SpecHelper.with_sample("pluto.ppm") do |io|
+        image = Pluto::RGBAImage.from_ppm(io)
+        Digest::SHA1.hexdigest(image.to_jpeg).should eq "d7a21c69034175411176d404b7e1c03e4a50a938"
+      end
+    end
+
+    it "works with String" do
+      SpecHelper.with_sample("pluto.ppm") do |io|
+        image = Pluto::RGBAImage.from_ppm(io.gets_to_end)
+        Digest::SHA1.hexdigest(image.to_jpeg).should eq "d7a21c69034175411176d404b7e1c03e4a50a938"
+      end
+    end
+
     it "works with RGBAImage" do
       data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)

--- a/spec/pluto/format/ppm_spec.cr
+++ b/spec/pluto/format/ppm_spec.cr
@@ -3,14 +3,14 @@ require "../../spec_helper"
 describe Pluto::Format::PPM do
   describe ".from_ppm" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "d7a21c69034175411176d404b7e1c03e4a50a938"
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "413b301c494bef9b80aab18b2f6cfd649780832f"
@@ -19,14 +19,14 @@ describe Pluto::Format::PPM do
 
   describe "#to_ppm" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "d7a21c69034175411176d404b7e1c03e4a50a938"
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
 
       Digest::SHA1.hexdigest(image.to_jpeg).should eq "413b301c494bef9b80aab18b2f6cfd649780832f"

--- a/spec/pluto/operation/bilinear_resize_spec.cr
+++ b/spec/pluto/operation/bilinear_resize_spec.cr
@@ -30,11 +30,11 @@ describe Pluto::Operation::BilinearResize do
   describe "#bilinear_resize!" do
     it "works with RGBAImage" do
       data = SpecHelper.pluto_ppm
+
       image = Pluto::RGBAImage.from_ppm(data)
       image.bilinear_resize!(480, 360)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "7a18aea5a8a33fbb74cd12182172fd266f8b9c60"
 
-      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.bilinear_resize!(800, 600)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "4091684fe7b44c6d9a61ff732ab8d6f26b129e88"
@@ -42,11 +42,11 @@ describe Pluto::Operation::BilinearResize do
 
     it "works with GrayscaleImage" do
       data = SpecHelper.pluto_ppm
+
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.bilinear_resize!(480, 360)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "e99a957526b32dfbfabff4b580335944a1659b67"
 
-      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.bilinear_resize!(800, 600)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "9fe83c54452750e436da32b42a9cad5e8a904c1b"

--- a/spec/pluto/operation/bilinear_resize_spec.cr
+++ b/spec/pluto/operation/bilinear_resize_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::BilinearResize do
   describe "#bilinear_resize" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       downsized_image = original_image.bilinear_resize(480, 360)
@@ -15,7 +15,7 @@ describe Pluto::Operation::BilinearResize do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       downsized_image = original_image.bilinear_resize(480, 360)
@@ -29,24 +29,24 @@ describe Pluto::Operation::BilinearResize do
 
   describe "#bilinear_resize!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
-
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.bilinear_resize!(480, 360)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "7a18aea5a8a33fbb74cd12182172fd266f8b9c60"
 
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.bilinear_resize!(800, 600)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "4091684fe7b44c6d9a61ff732ab8d6f26b129e88"
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
-
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.bilinear_resize!(480, 360)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "e99a957526b32dfbfabff4b580335944a1659b67"
 
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.bilinear_resize!(800, 600)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "9fe83c54452750e436da32b42a9cad5e8a904c1b"

--- a/spec/pluto/operation/box_blur_spec.cr
+++ b/spec/pluto/operation/box_blur_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::BoxBlur do
   describe "#box_blur" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       blurred_image = original_image.box_blur(10)
@@ -13,7 +13,7 @@ describe Pluto::Operation::BoxBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       blurred_image = original_image.box_blur(10)
@@ -25,7 +25,7 @@ describe Pluto::Operation::BoxBlur do
 
   describe "#box_blur!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::RGBAImage.from_ppm(data)
       image.box_blur!(10)
@@ -34,7 +34,7 @@ describe Pluto::Operation::BoxBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.box_blur!(10)

--- a/spec/pluto/operation/brightness_spec.cr
+++ b/spec/pluto/operation/brightness_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::Brightness do
   describe "#brightness" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       brightened_image = original_image.brightness(1.4)
@@ -15,7 +15,7 @@ describe Pluto::Operation::Brightness do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       brightened_image = original_image.brightness(1.4)
@@ -29,24 +29,24 @@ describe Pluto::Operation::Brightness do
 
   describe "#brightness!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
-
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.brightness!(1.4)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "e276fd23c577bf986b0e75c3f8e43cc936307450"
 
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.brightness!(0.6)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "f84f1a69db111484616cb1b9bd58e92a608c50e7"
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
-
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.brightness!(1.4)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "16e5ec301a72d75ea53c62c8f7b66b0b583455e4"
 
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.brightness!(0.6)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "c3d8d9c5c221ae0672f92def1ccdc8d0aea13d5d"

--- a/spec/pluto/operation/brightness_spec.cr
+++ b/spec/pluto/operation/brightness_spec.cr
@@ -30,11 +30,11 @@ describe Pluto::Operation::Brightness do
   describe "#brightness!" do
     it "works with RGBAImage" do
       data = SpecHelper.pluto_ppm
+
       image = Pluto::RGBAImage.from_ppm(data)
       image.brightness!(1.4)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "e276fd23c577bf986b0e75c3f8e43cc936307450"
 
-      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.brightness!(0.6)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "f84f1a69db111484616cb1b9bd58e92a608c50e7"
@@ -42,11 +42,11 @@ describe Pluto::Operation::Brightness do
 
     it "works with GrayscaleImage" do
       data = SpecHelper.pluto_ppm
+
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.brightness!(1.4)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "16e5ec301a72d75ea53c62c8f7b66b0b583455e4"
 
-      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.brightness!(0.6)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "c3d8d9c5c221ae0672f92def1ccdc8d0aea13d5d"

--- a/spec/pluto/operation/channel_swap_spec.cr
+++ b/spec/pluto/operation/channel_swap_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::ChannelSwap do
   describe "#channel_swap" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       bgr_image = original_image.channel_swap(:red, :blue)
@@ -13,7 +13,7 @@ describe Pluto::Operation::ChannelSwap do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       expect_raises(Exception, /Unknown channel type Red for GrayscaleImage/) do
@@ -24,7 +24,7 @@ describe Pluto::Operation::ChannelSwap do
 
   describe "#channel_swap!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::RGBAImage.from_ppm(data)
       image.channel_swap!(:red, :blue)

--- a/spec/pluto/operation/contrast_spec.cr
+++ b/spec/pluto/operation/contrast_spec.cr
@@ -30,11 +30,11 @@ describe Pluto::Operation::Contrast do
   describe "#contrast!" do
     it "works with RGBAImage" do
       data = SpecHelper.pluto_ppm
+
       image = Pluto::RGBAImage.from_ppm(data)
       image.contrast!(128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "d773339697e9c3ed2ea188ecc1adbbe73dbc1ba5"
 
-      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.contrast!(-128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "c2269bee571172cf97377547e5e9de9b91e552c5"
@@ -42,11 +42,11 @@ describe Pluto::Operation::Contrast do
 
     it "works with GrayscaleImage" do
       data = SpecHelper.pluto_ppm
+
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.contrast!(128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "5aa2004129f7267c851b8055cdd93da205ab7483"
 
-      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.contrast!(-128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "9f6321f4b1387dd03b47a266a32905615e652e26"

--- a/spec/pluto/operation/contrast_spec.cr
+++ b/spec/pluto/operation/contrast_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::Contrast do
   describe "#contrast" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       positive_image = original_image.contrast(128)
@@ -15,7 +15,7 @@ describe Pluto::Operation::Contrast do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       positive_image = original_image.contrast(128)
@@ -29,24 +29,24 @@ describe Pluto::Operation::Contrast do
 
   describe "#contrast!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
-
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.contrast!(128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "d773339697e9c3ed2ea188ecc1adbbe73dbc1ba5"
 
+      data = SpecHelper.pluto_ppm
       image = Pluto::RGBAImage.from_ppm(data)
       image.contrast!(-128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "c2269bee571172cf97377547e5e9de9b91e552c5"
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
-
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.contrast!(128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "5aa2004129f7267c851b8055cdd93da205ab7483"
 
+      data = SpecHelper.pluto_ppm
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.contrast!(-128)
       Digest::SHA1.hexdigest(image.to_ppm).should eq "9f6321f4b1387dd03b47a266a32905615e652e26"

--- a/spec/pluto/operation/gaussian_blur_spec.cr
+++ b/spec/pluto/operation/gaussian_blur_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::GaussianBlur do
   describe "#gaussian_blur" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       blurred_image = original_image.gaussian_blur(10)
@@ -13,7 +13,7 @@ describe Pluto::Operation::GaussianBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       blurred_image = original_image.gaussian_blur(10)
@@ -25,7 +25,7 @@ describe Pluto::Operation::GaussianBlur do
 
   describe "#gaussian_blur!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::RGBAImage.from_ppm(data)
       image.gaussian_blur!(10)
@@ -34,7 +34,7 @@ describe Pluto::Operation::GaussianBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.gaussian_blur!(10)

--- a/spec/pluto/operation/horizontal_blur_spec.cr
+++ b/spec/pluto/operation/horizontal_blur_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::HorizontalBlur do
   describe "#horizontal_blur" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       blurred_image = original_image.horizontal_blur(10)
@@ -13,7 +13,7 @@ describe Pluto::Operation::HorizontalBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       blurred_image = original_image.horizontal_blur(10)
@@ -25,7 +25,7 @@ describe Pluto::Operation::HorizontalBlur do
 
   describe "#horizontal_blur!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::RGBAImage.from_ppm(data)
       image.horizontal_blur!(10)
@@ -34,7 +34,7 @@ describe Pluto::Operation::HorizontalBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.horizontal_blur!(10)

--- a/spec/pluto/operation/vertical_blur_spec.cr
+++ b/spec/pluto/operation/vertical_blur_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe Pluto::Operation::VerticalBlur do
   describe "#vertical_blur" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::RGBAImage.from_ppm(data)
       blurred_image = original_image.vertical_blur(10)
@@ -13,7 +13,7 @@ describe Pluto::Operation::VerticalBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       original_image = Pluto::GrayscaleImage.from_ppm(data)
       blurred_image = original_image.vertical_blur(10)
@@ -25,7 +25,7 @@ describe Pluto::Operation::VerticalBlur do
 
   describe "#vertical_blur!" do
     it "works with RGBAImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::RGBAImage.from_ppm(data)
       image.vertical_blur!(10)
@@ -34,7 +34,7 @@ describe Pluto::Operation::VerticalBlur do
     end
 
     it "works with GrayscaleImage" do
-      data = SpecHelper.read_sample("pluto.ppm")
+      data = SpecHelper.pluto_ppm
 
       image = Pluto::GrayscaleImage.from_ppm(data)
       image.vertical_blur!(10)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,11 +4,21 @@ require "spec"
 require "../src/pluto"
 
 module SpecHelper
-  def self.pluto_ppm : Bytes
-    @@pluto_ppm_bytes ||= File.open("lib/pluto_samples/pluto.ppm").getb_to_end
+  def self.with_sample(name : String)
+    File.open("lib/pluto_samples/#{name}") do |file|
+      yield file
+    end
   end
 
+  @@pluto_ppm_bytes : Bytes?
+
+  def self.pluto_ppm : Bytes
+    @@pluto_ppm_bytes ||= with_sample("pluto.ppm", &.getb_to_end)
+  end
+
+  @@pluto_jpg_bytes : Bytes?
+
   def self.pluto_jpg : Bytes
-    @@pluto_jpg_bytes ||= File.open("lib/pluto_samples/pluto.jpg").getb_to_end
+    @@pluto_jpg_bytes ||= with_sample("pluto.jpg", &.getb_to_end)
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,15 +4,11 @@ require "spec"
 require "../src/pluto"
 
 module SpecHelper
-  def self.pluto_ppm : IO
-    IO::Memory.new(@@pluto_ppm_bytes ||= begin
-      File.open("lib/pluto_samples/pluto.ppm").getb_to_end
-    end)
+  def self.pluto_ppm : Bytes
+    @@pluto_ppm_bytes ||= File.open("lib/pluto_samples/pluto.ppm").getb_to_end
   end
 
-  def self.pluto_jpg : IO
-    IO::Memory.new(@@pluto_jpg_bytes ||= begin
-      File.open("lib/pluto_samples/pluto.jpg").getb_to_end
-    end)
+  def self.pluto_jpg : Bytes
+    @@pluto_jpg_bytes ||= File.open("lib/pluto_samples/pluto.jpg").getb_to_end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,13 +4,15 @@ require "spec"
 require "../src/pluto"
 
 module SpecHelper
-  def self.read_sample(name : String) : String
-    File.read("lib/pluto_samples/#{name}")
-  end
-
   def self.pluto_ppm : IO
     IO::Memory.new(@@pluto_ppm_bytes ||= begin
       File.open("lib/pluto_samples/pluto.ppm").getb_to_end
+    end)
+  end
+
+  def self.pluto_jpg : IO
+    IO::Memory.new(@@pluto_jpg_bytes ||= begin
+      File.open("lib/pluto_samples/pluto.jpg").getb_to_end
     end)
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,4 +7,10 @@ module SpecHelper
   def self.read_sample(name : String) : String
     File.read("lib/pluto_samples/#{name}")
   end
+
+  def self.pluto_ppm : IO
+    IO::Memory.new(@@pluto_ppm_bytes ||= begin
+      File.open("lib/pluto_samples/pluto.ppm").getb_to_end
+    end)
+  end
 end

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -65,7 +65,7 @@ module Pluto::Format::JPEG
     handle = LibJPEGTurbo.init_compress
     image_data = IO::Memory.new(size * 3)
     size.times do |index|
-      image_data.write_byte(red.unsafe_fetch(index) )
+      image_data.write_byte(red.unsafe_fetch(index))
       image_data.write_byte(green.unsafe_fetch(index))
       image_data.write_byte(blue.unsafe_fetch(index))
     end

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -45,8 +45,7 @@ module Pluto::Format::JPEG
     end
 
     def self.from_jpeg(image_data : String) : self
-      io = IO::Memory.new(image_data)
-      from_jpeg(io)
+      from_jpeg(image_data.to_slice)
     end
 
     private def self.check(handle, code)

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -64,18 +64,17 @@ module Pluto::Format::JPEG
 
   private def buffer(quality : Int32 = 100) : Tuple(Pointer(UInt8), UInt64)
     handle = LibJPEGTurbo.init_compress
-    image_data = String.build do |string|
-      size.times do |index|
-        string.write_byte(red.unsafe_fetch(index))
-        string.write_byte(green.unsafe_fetch(index))
-        string.write_byte(blue.unsafe_fetch(index))
-      end
+    image_data = IO::Memory.new(size * 3)
+    size.times do |index|
+      image_data.write_byte(red.unsafe_fetch(index) )
+      image_data.write_byte(green.unsafe_fetch(index))
+      image_data.write_byte(blue.unsafe_fetch(index))
     end
 
     buffer = Array(UInt8).new.to_unsafe
     check handle, LibJPEGTurbo.compress2(
       handle,
-      image_data,
+      image_data.buffer,
       @width,
       0,
       @height,

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -1,8 +1,6 @@
 module Pluto::Format::JPEG
   macro included
-    def self.from_jpeg(io : IO) : self
-      image_data = io.getb_to_end
-
+    def self.from_jpeg(image_data : Bytes) : self
       handle = LibJPEGTurbo.init_decompress
       check handle, LibJPEGTurbo.decompress_header3(
         handle,
@@ -40,6 +38,10 @@ module Pluto::Format::JPEG
       end
 
       new(red, green, blue, alpha, width, height)
+    end
+
+    def self.from_jpeg(io : IO) : self
+      from_jpeg(io.getb_to_end)
     end
 
     def self.from_jpeg(image_data : String) : self

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -1,15 +1,13 @@
 module Pluto::Format::JPEG
   macro included
     def self.from_jpeg(io : IO) : self
-      from_jpeg(String.new(io.getb_to_end))
-    end
+      image_data = io.getb_to_end
 
-    def self.from_jpeg(image_data : String) : self
       handle = LibJPEGTurbo.init_decompress
       check handle, LibJPEGTurbo.decompress_header3(
         handle,
         image_data,
-        image_data.bytesize,
+        image_data.size,
         out width,
         out height,
         out _subsampling,
@@ -19,7 +17,7 @@ module Pluto::Format::JPEG
       check handle, LibJPEGTurbo.decompress2(
         handle,
         image_data,
-        LibC::ULong.new(image_data.bytesize),
+        LibC::ULong.new(image_data.size),
         buffer,
         width,
         0,
@@ -42,6 +40,11 @@ module Pluto::Format::JPEG
       end
 
       new(red, green, blue, alpha, width, height)
+    end
+
+    def self.from_jpeg(image_data : String) : self
+      io = IO::Memory.new(image_data)
+      from_jpeg(io)
     end
 
     private def self.check(handle, code)

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -53,16 +53,14 @@ module Pluto::Format::JPEG
   end
 
   def to_jpeg(io : IO, quality : Int32 = 100) : Nil
-    buf, size = buffer(quality)
-    io.write(Slice(UInt8).new(buf, size))
+    io.write(buffer(quality))
   end
 
   def to_jpeg(quality : Int32 = 100) : String
-    buf, size = buffer(quality)
-    String.new(buf, size)
+    String.new(buffer(quality))
   end
 
-  private def buffer(quality : Int32 = 100) : Tuple(Pointer(UInt8), UInt64)
+  private def buffer(quality : Int32 = 100) : Bytes
     handle = LibJPEGTurbo.init_compress
     image_data = IO::Memory.new(size * 3)
     size.times do |index|
@@ -87,7 +85,7 @@ module Pluto::Format::JPEG
     )
     check handle, LibJPEGTurbo.destroy(handle)
 
-    {buffer, size}
+    Bytes.new(buffer, size)
   end
 
   private def check(handle, code)

--- a/src/pluto/format/ppm.cr
+++ b/src/pluto/format/ppm.cr
@@ -36,8 +36,7 @@ module Pluto::Format::PPM
     end
 
     def self.from_ppm(image_data : String) : self
-      io = IO::Memory.new(image_data)
-      from_ppm(io)
+      from_ppm(image_data.to_slice)
     end
   end
 

--- a/src/pluto/format/ppm.cr
+++ b/src/pluto/format/ppm.cr
@@ -31,6 +31,10 @@ module Pluto::Format::PPM
       end
     end
 
+    def self.from_ppm(image_data : Bytes) : self
+      from_ppm(IO::Memory.new(image_data))
+    end
+
     def self.from_ppm(image_data : String) : self
       io = IO::Memory.new(image_data)
       from_ppm(io)


### PR DESCRIPTION
Closes #12

With this PR .from_ppm and .from_jpg can be used with `IO`, `String` and `Bytes` (aka `Slice(UInt8)`) with minimum intermediate allocations.

I also changed the spec helpers a bit to read once the file in most of the cases. This is opinionated, it can be reverted if preferred.

I changed some buffer handling to be more idiomatic. Along that I think I notice some memory issue with how libturbo-jpeg is used, but I would try to address that in another PR.