### PR TITLE
Introduce Mask class, `apply` operators, and a `threshold` method on GrayscaleImage

### DIFF
--- a/spec/pluto/mask_spec.cr
+++ b/spec/pluto/mask_spec.cr
@@ -1,0 +1,324 @@
+require "../spec_helper"
+
+describe Pluto::Mask do
+  it "initializes with width and height" do
+    mask = Pluto::Mask.new(3, 3)
+    mask.bits.should eq BitArray.new(9, true)
+    mask.size.should eq 9
+  end
+
+  it "initializes with bit array and width" do
+    bits = BitArray.new(9, false)
+    mask = Pluto::Mask.new(3, bits)
+    mask.bits.should eq bits
+    mask.width.should eq 3
+    mask.height.should eq 3
+    mask.size.should eq 9
+  end
+
+  it "initializes with block" do
+    mask = Pluto::Mask.new(4, 4) { |x, y| (1..2).includes?(x) && (1..2).includes?(y) }
+    mask.size.should eq 16
+    mask.width.should eq 4
+    mask.height.should eq 4
+    mask[0.., 0..].should eq [
+      SpecHelper.bit_arr(4, 0b0000),
+      SpecHelper.bit_arr(4, 0b0110),
+      SpecHelper.bit_arr(4, 0b0110),
+      SpecHelper.bit_arr(4, 0b0000),
+    ]
+  end
+
+  it "initializes from integer" do
+    mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+    mask.size.should eq 16
+    mask.width.should eq 4
+    mask.height.should eq 4
+    mask[0.., 0..].should eq [
+      SpecHelper.bit_arr(4, 0b1010),
+      SpecHelper.bit_arr(4, 0b0101),
+      SpecHelper.bit_arr(4, 0b1010),
+      SpecHelper.bit_arr(4, 0b0101),
+    ]
+  end
+
+  it "raises if bit array size isn't evenly divisible by width" do
+    expect_raises(Exception, /BitArray size 3 must be an even number of 2/) do
+      Pluto::Mask.new(2, BitArray.new(3))
+    end
+  end
+
+  it "#[]" do
+    bits = BitArray.new(4, false)
+    bits[1] = true
+    bits[3] = true
+
+    # Mask looks like:
+    # 0 1
+    # 0 1
+
+    mask = Pluto::Mask.new(2, bits)
+    mask[0, 0].should be_false
+    mask[1, 0].should be_true
+    mask[0, 1].should be_false
+    mask[1, 1].should be_true
+  end
+
+  context "raises index error when" do
+    mask = Pluto::Mask.new(2, BitArray.new(4))
+    it "coordinate is outside of height" do
+      expect_raises(IndexError, "Out of bounds: this mask is 2x2, and (0,2) is outside of that") do
+        mask[0, 2]
+      end
+    end
+
+    it "coordinate is outside of width" do
+      expect_raises(IndexError, "Out of bounds: this mask is 2x2, and (2,0) is outside of that") do
+        mask[2, 0]
+      end
+    end
+
+    it "x range is outside of width" do
+      expect_raises(IndexError, "Range 1..3 exceeds bounds of 2") do
+        mask[1..3, 0]
+      end
+    end
+
+    it "y range is outside of height" do
+      expect_raises(IndexError, "Range 1..3 exceeds bounds of 2") do
+        mask[1..3, 0]
+      end
+    end
+  end
+
+  context "using #[] with checkerboard pattern" do
+    mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+
+    it "supports single point" do
+      mask[0, 0].should be_true
+      mask[0, 1].should be_false
+      mask[1, 0].should be_false
+      mask[1, 1].should be_true
+      mask[3, 3].should be_true
+    end
+
+    it "supports range for x" do
+      mask[0..3, 0].should eq SpecHelper.bit_arr(4, 0b1010)
+      mask[0..3, 1].should eq SpecHelper.bit_arr(4, 0b0101)
+      mask[0..3, 2].should eq SpecHelper.bit_arr(4, 0b1010)
+      mask[0..3, 3].should eq SpecHelper.bit_arr(4, 0b0101)
+    end
+
+    it "supports range for y" do
+      mask[0, 0..3].should eq SpecHelper.bit_arr(4, 0b1010)
+      mask[1, 0..3].should eq SpecHelper.bit_arr(4, 0b0101)
+      mask[2, 0..3].should eq SpecHelper.bit_arr(4, 0b1010)
+      mask[3, 0..3].should eq SpecHelper.bit_arr(4, 0b0101)
+    end
+
+    it "supports finite range for both x and y" do
+      mask[0..3, 0..3].should eq [
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b0101),
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+    end
+
+    it "supports infinite range for both x and y" do
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b0101),
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+    end
+
+    it "initializes from a larger mask" do
+      other_mask = Pluto::Mask.new(mask[1..2, 1..2])
+      other_mask[0..-1, 0..-1].should eq [
+        SpecHelper.bit_arr(2, 0b10),
+        SpecHelper.bit_arr(2, 0b01),
+      ]
+    end
+  end
+
+  context "using #[] with unique pattern" do
+    mask = Pluto::Mask.new(4, 4, 0b0000111001101001)
+
+    it "supports single point" do
+      mask[0, 0].should be_false
+      mask[0, 1].should be_true
+      mask[1, 0].should be_false
+      mask[1, 1].should be_true
+      mask[3, 3].should be_true
+    end
+
+    it "supports range for x" do
+      mask[0..3, 0].should eq SpecHelper.bit_arr(4, 0b0000)
+      mask[0..3, 1].should eq SpecHelper.bit_arr(4, 0b1110)
+      mask[0..3, 2].should eq SpecHelper.bit_arr(4, 0b0110)
+      mask[0..3, 3].should eq SpecHelper.bit_arr(4, 0b1001)
+    end
+
+    it "supports range for y" do
+      mask[0, 0..3].should eq SpecHelper.bit_arr(4, 0b0101)
+      mask[1, 0..3].should eq SpecHelper.bit_arr(4, 0b0110)
+      mask[2, 0..3].should eq SpecHelper.bit_arr(4, 0b0110)
+      mask[3, 0..3].should eq SpecHelper.bit_arr(4, 0b0001)
+    end
+
+    it "supports finite range for both x and y" do
+      mask[0..3, 0..3].should eq [
+        SpecHelper.bit_arr(4, 0b0000),
+        SpecHelper.bit_arr(4, 0b1110),
+        SpecHelper.bit_arr(4, 0b0110),
+        SpecHelper.bit_arr(4, 0b1001),
+      ]
+    end
+
+    it "supports infinite range for both x and y" do
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b0000),
+        SpecHelper.bit_arr(4, 0b1110),
+        SpecHelper.bit_arr(4, 0b0110),
+        SpecHelper.bit_arr(4, 0b1001),
+      ]
+    end
+
+    it "initializes from a larger mask" do
+      other_mask = Pluto::Mask.new(mask[0..2, 1..2])
+      other_mask[0..-1, 0..-1].should eq [
+        SpecHelper.bit_arr(3, 0b111),
+        SpecHelper.bit_arr(3, 0b011),
+      ]
+    end
+  end
+
+  it "#inverts" do
+    mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+    mask.invert.should eq Pluto::Mask.new(4, 4, 0b0101101001011010)
+    mask.should eq Pluto::Mask.new(4, 4, 0b1010010110100101)
+  end
+
+  it "#inverts!" do
+    mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+    mask.invert!
+    mask.should eq Pluto::Mask.new(4, 4, 0b0101101001011010)
+  end
+
+  context "using #[]= using checkerboard pattern" do
+    it "sets a single point" do
+      mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+      mask[1, 0] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1110),
+        SpecHelper.bit_arr(4, 0b0101),
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+
+      mask[3, 2] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1110),
+        SpecHelper.bit_arr(4, 0b0101),
+        SpecHelper.bit_arr(4, 0b1011),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+
+      mask[1, 1] = false
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1110),
+        SpecHelper.bit_arr(4, 0b0001),
+        SpecHelper.bit_arr(4, 0b1011),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+    end
+
+    it "sets range for x and single point for y" do
+      mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+      mask[0..3, 0] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b0101),
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+
+      mask[1..2, 2] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b0101),
+        SpecHelper.bit_arr(4, 0b1110),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+
+      mask[1..2, 2] = false
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b0101),
+        SpecHelper.bit_arr(4, 0b1000),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+    end
+
+    it "sets range for y and single point for x" do
+      mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+      mask[0, 0..3] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b1101),
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b1101),
+      ]
+
+      mask[2, 1..2] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b1101),
+      ]
+
+      mask[2, 1..2] = false
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b1101),
+        SpecHelper.bit_arr(4, 0b1000),
+        SpecHelper.bit_arr(4, 0b1101),
+      ]
+    end
+
+    it "sets range for both x and y" do
+      mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+      mask[1..2, 1..2] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1010),
+        SpecHelper.bit_arr(4, 0b0111),
+        SpecHelper.bit_arr(4, 0b1110),
+        SpecHelper.bit_arr(4, 0b0101),
+      ]
+
+      mask[0.., 0..] = true
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b1111),
+      ]
+
+      mask[1..2, 1..2] = false
+      mask[0.., 0..].should eq [
+        SpecHelper.bit_arr(4, 0b1111),
+        SpecHelper.bit_arr(4, 0b1001),
+        SpecHelper.bit_arr(4, 0b1001),
+        SpecHelper.bit_arr(4, 0b1111),
+      ]
+    end
+  end
+
+  it "converts to grayscale" do
+    mask = Pluto::Mask.new(4, 4, 0b1010010110100101)
+    Digest::SHA1.hexdigest(mask.to_gray.to_ppm).should eq "3f5741961d8c2290ca93988c23c7f13bc97c66aa"
+  end
+end

--- a/spec/pluto/operation/mask_apply_spec.cr
+++ b/spec/pluto/operation/mask_apply_spec.cr
@@ -2,27 +2,67 @@ require "../../spec_helper"
 
 describe Pluto::Operation::MaskApply do
   describe "#apply" do
-    it "works with GrayscaleImage" do
-      image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
-      mask = Pluto::Mask.new(image.width, image.height)
-      Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
+    describe "with Grayscale" do
+      it "changes nothing when initialized as all true" do
+        image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        mask = Pluto::Mask.new(image)
+        Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
+      end
+
+      it "blacks out half the image" do
+        image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        mask = Pluto::Mask.new(image)
+        mask[0..(image.width//2), 0..] = false
+        Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "4013960c0180c5d7a1741c13456055853bf54416"
+      end
+
+      it "applies threshold" do
+        image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        Digest::SHA1.hexdigest(image.apply(image.threshold(16)).to_ppm).should eq "2e0b4f156fa6978b7c7bf024068a58cb8d13d82b"
+      end
+
+      it "applies threshold through mask" do
+        image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        Digest::SHA1.hexdigest(image.threshold(16).apply(image).to_ppm).should eq "2e0b4f156fa6978b7c7bf024068a58cb8d13d82b"
+      end
     end
 
-    it "blacks out half the image" do
-      image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
-      mask = Pluto::Mask.new(image.width, image.height)
-      mask[0..(image.width//2), 0..] = false
-      Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "4013960c0180c5d7a1741c13456055853bf54416"
-    end
+    describe "with RGBAImage" do
+      it "changes nothing when initialized as all true" do
+        image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        mask = Pluto::Mask.new(image)
+        Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
+      end
 
-    it "applies threshold" do
-      image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
-      Digest::SHA1.hexdigest(image.apply(image.to_gray.threshold(16)).to_ppm).should eq "62409fe550b1d7d87757fbf7c9612514cae72acd"
-    end
+      it "blacks out half the image" do
+        image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        mask = Pluto::Mask.new(image)
+        mask[0..(image.width//2), 0..] = false
+        Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "d60dbccb569875392fa91054463e4de30e661e7b"
+      end
 
-    it "applies threshold through mask" do
-      image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
-      Digest::SHA1.hexdigest(image.to_gray.threshold(16).apply(image).to_ppm).should eq "62409fe550b1d7d87757fbf7c9612514cae72acd"
+      it "applies threshold" do
+        image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        Digest::SHA1.hexdigest(image.apply(image.to_gray.threshold(16)).to_ppm).should eq "62409fe550b1d7d87757fbf7c9612514cae72acd"
+      end
+
+      it "applies threshold through mask" do
+        image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+        Digest::SHA1.hexdigest(image.to_gray.threshold(16).apply(image).to_ppm).should eq "62409fe550b1d7d87757fbf7c9612514cae72acd"
+      end
     end
+  end
+
+  it "draws a blue pluto" do
+    image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+    Digest::SHA1.hexdigest(
+      image
+        .to_gray
+        .threshold(16)
+        .apply(image) do |_, _, _, channel_type|
+          channel_type == Pluto::ChannelType::Blue ? 255u8 : 0u8
+        end
+        .to_ppm
+    ).should eq "a72ff68332ecffec70d1766114ed5202e944488f"
   end
 end

--- a/spec/pluto/operation/mask_apply_spec.cr
+++ b/spec/pluto/operation/mask_apply_spec.cr
@@ -14,5 +14,10 @@ describe Pluto::Operation::MaskApply do
       mask[0..(image.width//2), 0..] = false
       Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "4013960c0180c5d7a1741c13456055853bf54416"
     end
+
+    it "applies threshold" do
+      image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+      Digest::SHA1.hexdigest(image.apply(image.to_gray.threshold(16)).to_ppm).should eq "62409fe550b1d7d87757fbf7c9612514cae72acd"
+    end
   end
 end

--- a/spec/pluto/operation/mask_apply_spec.cr
+++ b/spec/pluto/operation/mask_apply_spec.cr
@@ -19,5 +19,10 @@ describe Pluto::Operation::MaskApply do
       image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
       Digest::SHA1.hexdigest(image.apply(image.to_gray.threshold(16)).to_ppm).should eq "62409fe550b1d7d87757fbf7c9612514cae72acd"
     end
+
+    it "applies threshold through mask" do
+      image = Pluto::RGBAImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+      Digest::SHA1.hexdigest(image.to_gray.threshold(16).apply(image).to_ppm).should eq "62409fe550b1d7d87757fbf7c9612514cae72acd"
+    end
   end
 end

--- a/spec/pluto/operation/mask_apply_spec.cr
+++ b/spec/pluto/operation/mask_apply_spec.cr
@@ -1,0 +1,18 @@
+require "../../spec_helper"
+
+describe Pluto::Operation::MaskApply do
+  describe "#apply" do
+    it "works with GrayscaleImage" do
+      image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+      mask = Pluto::Mask.new(image.width, image.height)
+      Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
+    end
+
+    it "blacks out half the image" do
+      image = Pluto::GrayscaleImage.from_ppm(SpecHelper.read_sample("pluto.ppm"))
+      mask = Pluto::Mask.new(image.width, image.height)
+      mask[0..(image.width//2), 0..] = false
+      Digest::SHA1.hexdigest(image.apply(mask).to_ppm).should eq "4013960c0180c5d7a1741c13456055853bf54416"
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,4 +7,8 @@ module SpecHelper
   def self.read_sample(name : String) : String
     File.read("lib/pluto_samples/#{name}")
   end
+
+  def self.bit_arr(size : Int32, int : Int)
+    BitArray.new(size) { |i| int.bit(size - i - 1) > 0 }
+  end
 end

--- a/src/pluto/grayscale_image.cr
+++ b/src/pluto/grayscale_image.cr
@@ -60,4 +60,16 @@ class Pluto::GrayscaleImage < Pluto::Image
   def size : Int32
     @width * @height
   end
+
+  def mask_from(&block : (Int32, Int32, UInt8) -> Bool) : Mask
+    Mask.new(width, BitArray.new(size) do |i|
+      block.call(i % width, i // width, @gray[i])
+    end)
+  end
+
+  def threshold(threshold : Int) : Mask
+    mask_from do |_, _, pixel|
+      pixel >= threshold
+    end
+  end
 end

--- a/src/pluto/grayscale_image.cr
+++ b/src/pluto/grayscale_image.cr
@@ -54,7 +54,7 @@ class Pluto::GrayscaleImage < Pluto::Image
   end
 
   def to_rgba
-    RGBAImage.new(@gray.clone, @gray.clone, @gray.clone, Array(UInt8).new(size) { 1u8 }, width, height)
+    RGBAImage.new(@gray.clone, @gray.clone, @gray.clone, Array(UInt8).new(size) { 255u8 }, width, height)
   end
 
   def size : Int32

--- a/src/pluto/image.cr
+++ b/src/pluto/image.cr
@@ -15,6 +15,8 @@ abstract class Pluto::Image
     include Operation::GaussianBlur
     include Operation::HorizontalBlur
     include Operation::VerticalBlur
+
+    include Operation::MaskApply
   end
 
   macro forward_to_rgb_image(*methods)

--- a/src/pluto/mask.cr
+++ b/src/pluto/mask.cr
@@ -168,4 +168,8 @@ class Pluto::Mask
   def to_gray
     GrayscaleImage.new(bits.map { |b| b ? 255u8 : 0u8 }, width, height)
   end
+
+  def apply(image : Image) : Image
+    image.apply(self)
+  end
 end

--- a/src/pluto/mask.cr
+++ b/src/pluto/mask.cr
@@ -172,4 +172,8 @@ class Pluto::Mask
   def apply(image : Image) : Image
     image.apply(self)
   end
+
+  def apply(image : Image, &block : (Int32, Int32, UInt8, ChannelType) -> UInt8) : Image
+    image.apply(self, &block)
+  end
 end

--- a/src/pluto/mask.cr
+++ b/src/pluto/mask.cr
@@ -1,0 +1,171 @@
+require "bit_array"
+
+# Mask is a wrapper around BitArray, where each flag represents a boolean bit of information about a pixel
+# from an image. This can include whether a particular pixel has a value within certain conditions, OR
+# if that pixel should be zeroed out or not.
+#
+#
+# (x,y) - coordinates. Represent these positions in a Mask of size 10x10:
+#
+# [
+#   (0,0), (0,1), (0,2), (0,3), (0,4), (0,5), (0,6), (0,7), (0,8), (0,9),
+#   (1,0), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (1,8), (1,9),
+#   (2,0), (2,1), (2,2), (2,3), (2,4), (2,5), (2,6), (2,7), (2,8), (2,9),
+#   (3,0), (3,1), (3,2), (3,3), (3,4), (3,5), (3,6), (3,7), (3,8), (3,9),
+#   (4,0), (4,1), (4,2), (4,3), (4,4), (4,5), (4,6), (4,7), (4,8), (4,9),
+#   (5,0), (5,1), (5,2), (5,3), (5,4), (5,5), (5,6), (5,7), (5,8), (5,9),
+#   (6,0), (6,1), (6,2), (6,3), (6,4), (6,5), (6,6), (6,7), (6,8), (6,9),
+#   (7,0), (7,1), (7,2), (7,3), (7,4), (7,5), (7,6), (7,7), (7,8), (7,9),
+#   (8,0), (8,1), (8,2), (8,3), (8,4), (8,5), (8,6), (8,7), (8,8), (8,9),
+#   (9,0), (9,1), (9,2), (9,3), (9,4), (9,5), (9,6), (9,7), (9,8), (9,9),
+# ]
+#
+# And every position is a Bool value.
+#
+# Different ways to refer to coordinates
+# mask[0, 0] # => (0,0)
+# mask.at(0, 0) # => (0,0)
+# mask[0] # => (0,0), (1,0), (2,0), ..., (9,0)
+# mask[0..1] # => (0,0), (1,0), ..., (9,0), (0,1), (1,1), ..., (9,1)
+# mask[0..1, 4] # => (4,0), (4,1)
+# mask[3, 3..5] # => (3,3), (3,4), (3,5)
+# mask[2..3, 4..5] # => (2,4), (2,5), (3,4), (3,5)
+class Pluto::Mask
+  getter width : Int32
+  getter bits : BitArray
+
+  def initialize(@width, @bits)
+    raise "BitArray size #{@bits.size} must be an even number of #{@width}" unless (@bits.size % @width) == 0
+  end
+
+  def initialize(@width, height : Int32)
+    @bits = BitArray.new(@width * height, true)
+  end
+
+  def initialize(@width, height : Int32, &block : (Int32, Int32) -> Bool)
+    @bits = BitArray.new(@width * height) do |i|
+      block.call(i % @width, i // @width)
+    end
+  end
+
+  def initialize(@width, height : Int32, int : Int)
+    size = @width * height
+    @bits = BitArray.new(size) { |i| int.bit(size - i - 1) > 0 }
+  end
+
+  def initialize(image : Image)
+    @width = image.width
+    @bits = BitArray.new(image.size, true)
+  end
+
+  def initialize(other_bits : Array(BitArray))
+    raise "Can't create an empty mask" if other_bits.empty?
+    raise "Can't create an empty mask, first array is empty" if other_bits[0].empty?
+    raise "All sub arrays must be the same size" unless other_bits.map(&.size).uniq!.size == 1
+
+    @width = other_bits[0].size
+    @bits = BitArray.new(other_bits.size * @width)
+    other_bits.each_with_index do |arr, i|
+      arr.each_with_index do |bool, j|
+        @bits[i * @width + j] = bool
+      end
+    end
+  end
+
+  delegate size, to: bits
+
+  def height : Int32
+    @bits.size // width
+  end
+
+  def invert!
+    @bits.invert
+    self
+  end
+
+  def invert
+    new_bits = @bits.dup
+    new_bits.invert
+    Mask.new(width, new_bits)
+  end
+
+  def [](x : Int32, y : Int32) : Bool
+    raise IndexError.new("Out of bounds: this mask is #{width}x#{height}, and (#{x},#{y}) is outside of that") if x >= width || y >= height
+    @bits[y * width + x]
+  end
+
+  def at(index : Int32) : Bool
+    raise "Index #{index} exceeds mask size #{@bits.size}" if index >= size
+    @bits[index]
+  end
+
+  private def resolve_to_start_and_count(range, size) : Tuple(Int32, Int32)
+    start, count = Indexable.range_to_index_and_count(range, size) || raise IndexError.new("Unable to resolve range #{range} for mask dimension of #{size}")
+    raise IndexError.new("Range #{range} exceeds bounds of #{size}") if (start + count) > size
+    {start, count}
+  end
+
+  def [](xs : Range(Int32, Int32) | Range(Int32, Nil), y : Int32) : BitArray
+    start, count = resolve_to_start_and_count(xs, width)
+    BitArray.new(count) { |x| self[x + start, y] }
+  end
+
+  def [](x : Int32, ys : Range(Int32, Int32) | Range(Int32, Nil)) : BitArray
+    start, count = resolve_to_start_and_count(ys, height)
+    BitArray.new(count) { |y| self[x, y + start] }
+  end
+
+  def [](xs : Range(Int32, Int32) | Range(Int32, Nil), ys : Range(Int32, Int32) | Range(Int32, Nil)) : Array(BitArray)
+    start_x, count_x = resolve_to_start_and_count(xs, width)
+    start_y, count_y = resolve_to_start_and_count(ys, height)
+    count_y.times.to_a.map do |y|
+      BitArray.new(count_x) do |x|
+        self[x + start_x, y + start_y]
+      end
+    end
+  end
+
+  def ==(other : Mask)
+    width == other.width &&
+      bits == other.bits
+  end
+
+  def set(x : Int32, y : Int32, value : Bool) : Bool
+    raise IndexError.new("Out of bounds: this mask is #{width}x#{height}, and (#{x},#{y}) is outside of that") if x >= width || y >= height
+    @bits[y * width + x] = value
+  end
+
+  def []=(x : Int32, y : Int32, value : Bool) : Bool
+    self.set(x, y, value)
+  end
+
+  def []=(xs : Range(Int32, Int32) | Range(Int32, Nil), y : Int32, value : Bool) : Bool
+    raise IndexError.new("Out of bounds: #{y} is beyond the bounds of this mask's height of #{height}") if y >= height
+    start_x, count_x = resolve_to_start_and_count(xs, width)
+    @bits.fill(value, y * width + start_x, count_x)
+    value
+  end
+
+  def []=(x : Int32, ys : Range(Int32, Int32) | Range(Int32, Nil), value : Bool) : Bool
+    raise IndexError.new("Out of bounds: #{x} is beyond the bounds of this mask's width of #{width}") if x >= width
+    start_y, count_y = resolve_to_start_and_count(ys, height)
+    count_y.times.to_a.each do |y|
+      set(x, y + start_y, value)
+    end
+    value
+  end
+
+  def []=(xs : Range(Int32, Int32) | Range(Int32, Nil), ys : Range(Int32, Int32) | Range(Int32, Nil), value : Bool) : Bool
+    # IMPL: check ranges
+    start_x, count_x = resolve_to_start_and_count(xs, width)
+    start_y, count_y = resolve_to_start_and_count(ys, height)
+    count_y.times.to_a.each do |y|
+      @bits.fill(value, (y + start_y) * width + start_x, count_x)
+    end
+    value
+  end
+
+  def to_gray
+    GrayscaleImage.new(bits.map { |b| b ? 255u8 : 0u8 }, width, height)
+  end
+end

--- a/src/pluto/mask.cr
+++ b/src/pluto/mask.cr
@@ -25,8 +25,6 @@ require "bit_array"
 # Different ways to refer to coordinates
 # mask[0, 0] # => (0,0)
 # mask.at(0, 0) # => (0,0)
-# mask[0] # => (0,0), (1,0), (2,0), ..., (9,0)
-# mask[0..1] # => (0,0), (1,0), ..., (9,0), (0,1), (1,1), ..., (9,1)
 # mask[0..1, 4] # => (4,0), (4,1)
 # mask[3, 3..5] # => (3,3), (3,4), (3,5)
 # mask[2..3, 4..5] # => (2,4), (2,5), (3,4), (3,5)
@@ -89,11 +87,6 @@ class Pluto::Mask
     Mask.new(width, new_bits)
   end
 
-  def [](x : Int32, y : Int32) : Bool
-    raise IndexError.new("Out of bounds: this mask is #{width}x#{height}, and (#{x},#{y}) is outside of that") if x >= width || y >= height
-    @bits[y * width + x]
-  end
-
   def at(index : Int32) : Bool
     raise "Index #{index} exceeds mask size #{@bits.size}" if index >= size
     @bits[index]
@@ -103,6 +96,11 @@ class Pluto::Mask
     start, count = Indexable.range_to_index_and_count(range, size) || raise IndexError.new("Unable to resolve range #{range} for mask dimension of #{size}")
     raise IndexError.new("Range #{range} exceeds bounds of #{size}") if (start + count) > size
     {start, count}
+  end
+
+  def [](x : Int32, y : Int32) : Bool
+    raise IndexError.new("Out of bounds: this mask is #{width}x#{height}, and (#{x},#{y}) is outside of that") if x >= width || y >= height
+    @bits[y * width + x]
   end
 
   def [](xs : Range(Int32, Int32) | Range(Int32, Nil), y : Int32) : BitArray

--- a/src/pluto/operation/mask_apply.cr
+++ b/src/pluto/operation/mask_apply.cr
@@ -1,0 +1,29 @@
+module Pluto::Operation::MaskApply
+  def apply(mask : Mask) : self
+    clone.apply!(mask)
+  end
+
+  def apply(mask : Mask, &block : (Int32, Int32, UInt8, ChannelType) -> UInt8) : self
+    clone.apply!(mask, &block)
+  end
+
+  def apply!(mask : Mask) : self
+    raise "Mask of #{mask.width}x#{mask.height} doesn't match image dimensions #{width}x#{height}" unless mask.width == width && mask.height == height
+
+    each_channel do |channel|
+      channel.map_with_index! { |pixel, i| mask.at(i) ? pixel : 0u8 }
+    end
+    self
+  end
+
+  def apply!(mask : Mask, &block : (Int32, Int32, UInt8, ChannelType) -> UInt8) : self
+    raise "Mask of #{mask.width}x#{mask.height} doesn't match image dimensions #{width}x#{height}" unless mask.width == width && mask.height == height
+
+    each_channel do |channel, channel_type|
+      channel.map_with_index! do |pixel, i|
+        mask.at(i) ? block.call(i % width, i // width, pixel, channel_type) : pixel
+      end
+    end
+    self
+  end
+end


### PR DESCRIPTION
This introduces the `Mask` class, the workhorse object for feature identification. Essentially just a bit mask over images, it provides a map of which pixels contain a particular feature. It's also useful for altering images using the `apply` method (i.e. black out pixels that don't match the mask, or altering pixels that do match). This PR also contains the `threshold` and `mask_from` methods on the `GrayscaleImage` for mask generation (see note on these methods for additional details).

Future changes I want to add to the `Mask` class (names are all working titles only):
* `bounding_box` - return an x, y, width, and height where all `true` bits are contained. Useful for a potential `crop` or `draw_box` methods on images to identify _where_ particular features are on an image.
* `expand` and `contract` - fill in gaps in the `true` bits or remove them from the edges of `true` bit areas. Useful for cleaning up errant mask bits that are `false` that are surrounded by `true` bits (or vice versa).
* `regions` - return an Array of regions (same response as `bounding_box` above) where all `true` bits that touch each other are considered a "region", and the array represents all distinct areas in the mask that _don't_ connect.

Thoughts welcome! I like the implementation of `Mask`, but unsure about some of the interface method implementations. And of course, all of the above is contingent on @sanks64 accepting it :) Please let me know if I begin to overstep the purpose of this library and these methods and objects are better suited for its own. 