### PR TITLE
Add WebP support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       image: crystallang/crystal:latest-alpine
     steps:
       - uses: actions/checkout@v3
-      - run: apk add libjpeg-turbo libjpeg-turbo-dev
+      - run: apk add libjpeg-turbo libjpeg-turbo-dev libwebp libwebp-dev
       - run: shards install
       - run: bin/ameba
       - run: crystal tool format --check

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Image formats
   - JPEG (through [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo))
   - PPM
+  - WebP (through [libwebp](https://developers.google.com/speed/webp))
 - Image operations
   - Bilinear resize
   - Box blur

--- a/spec/pluto/format/webp_spec.cr
+++ b/spec/pluto/format/webp_spec.cr
@@ -1,0 +1,25 @@
+require "../../spec_helper"
+
+describe Pluto::Format::WebP do
+  describe ".from_webp and #to_webp" do
+    it "works with GrayscaleImage" do
+      with_sample("pluto.webp") do |io|
+        image = Pluto::GrayscaleImage.from_webp(io)
+        io = IO::Memory.new
+        image.to_webp(io)
+
+        digest(io.to_s).should eq "92678d201760ee50929ea344a81c76d5f61e70e6"
+      end
+    end
+
+    it "works with RGBAImage" do
+      with_sample("pluto.webp") do |io|
+        image = Pluto::RGBAImage.from_webp(io)
+        io = IO::Memory.new
+        image.to_webp(io)
+
+        digest(io.to_s).should eq "84238a32866606bfb7ebedc6d77fe3af11f03cab"
+      end
+    end
+  end
+end

--- a/src/pluto/bindings/lib_webp.cr
+++ b/src/pluto/bindings/lib_webp.cr
@@ -2,5 +2,6 @@
 lib LibWebP
   fun decode_rgba = WebPDecodeRGBA(data : UInt8*, data_size : LibC::SizeT, width : LibC::Int*, height : LibC::Int*) : UInt8*
   fun encode_lossless_rgba = WebPEncodeLosslessRGBA(rgba : UInt8*, width : LibC::Int, height : LibC::Int, stride : LibC::Int, output : UInt8**) : LibC::SizeT
+  fun free = WebPFree(ptr : Void*)
   fun get_info = WebPGetInfo(data : UInt8*, data_size : LibC::SizeT, width : LibC::Int*, height : LibC::Int*) : LibC::Int
 end

--- a/src/pluto/bindings/lib_webp.cr
+++ b/src/pluto/bindings/lib_webp.cr
@@ -1,4 +1,4 @@
-@[Link(ldflags: "-lwebp -lsharpyuv")]
+@[Link(ldflags: "-lwebp")]
 lib LibWebP
   fun decode_rgba = WebPDecodeRGBA(data : UInt8*, data_size : LibC::SizeT, width : LibC::Int*, height : LibC::Int*) : UInt8*
   fun encode_lossless_rgba = WebPEncodeLosslessRGBA(rgba : UInt8*, width : LibC::Int, height : LibC::Int, stride : LibC::Int, output : UInt8**) : LibC::SizeT

--- a/src/pluto/bindings/lib_webp.cr
+++ b/src/pluto/bindings/lib_webp.cr
@@ -1,0 +1,6 @@
+@[Link(ldflags: "-lwebp -lsharpyuv")]
+lib LibWebP
+  fun decode_rgba = WebPDecodeRGBA(data : UInt8*, data_size : LibC::SizeT, width : LibC::Int*, height : LibC::Int*) : UInt8*
+  fun encode_lossless_rgba = WebPEncodeLosslessRGBA(rgba : UInt8*, width : LibC::Int, height : LibC::Int, stride : LibC::Int, output : UInt8**) : LibC::SizeT
+  fun get_info = WebPGetInfo(data : UInt8*, data_size : LibC::SizeT, width : LibC::Int*, height : LibC::Int*) : LibC::Int
+end

--- a/src/pluto/exception.cr
+++ b/src/pluto/exception.cr
@@ -2,6 +2,7 @@ class Pluto::Exception < ::Exception
   getter error_code : Int32
 
   def initialize(@error_code : Int32)
+    super("Received `#{@error_code}` as the error code")
   end
 
   def initialize(handle : LibJPEGTurbo::Handle)

--- a/src/pluto/exception.cr
+++ b/src/pluto/exception.cr
@@ -1,8 +1,11 @@
 class Pluto::Exception < ::Exception
-  getter error_code : LibJPEGTurbo::ErrorCode
+  getter error_code : Int32
+
+  def initialize(@error_code : Int32)
+  end
 
   def initialize(handle : LibJPEGTurbo::Handle)
     super(String.new(LibJPEGTurbo.get_error_str(handle)))
-    @error_code = LibJPEGTurbo.get_error_code(handle)
+    @error_code = LibJPEGTurbo.get_error_code(handle).to_i
   end
 end

--- a/src/pluto/format/webp.cr
+++ b/src/pluto/format/webp.cr
@@ -10,19 +10,19 @@ module Pluto::Format::WebP
         pointerof(height)
       )
 
-      bytes = Bytes.new(buffer, width * height * 4)
       red = Array.new(width * height) { 0u8 }
       green = Array.new(width * height) { 0u8 }
       blue = Array.new(width * height) { 0u8 }
       alpha = Array.new(width * height) { 0u8 }
-      pixels = bytes.each_slice(4).to_a
 
       (width * height).times do |index|
-        red.unsafe_put(index, pixels.unsafe_fetch(index).unsafe_fetch(0))
-        green.unsafe_put(index, pixels.unsafe_fetch(index).unsafe_fetch(1))
-        blue.unsafe_put(index, pixels.unsafe_fetch(index).unsafe_fetch(2))
-        alpha.unsafe_put(index, pixels.unsafe_fetch(index).unsafe_fetch(3))
+        red.unsafe_put(index, buffer[index * 4])
+        green.unsafe_put(index, buffer[index * 4 + 1])
+        blue.unsafe_put(index, buffer[index * 4 + 2])
+        alpha.unsafe_put(index, buffer[index * 4 + 3])
       end
+
+      LibWebP.free(buffer)
 
       new(red, green, blue, alpha, width, height)
     end

--- a/src/pluto/format/webp.cr
+++ b/src/pluto/format/webp.cr
@@ -58,6 +58,8 @@ module Pluto::Format::WebP
 
     bytes = Bytes.new(buffer, size)
     io.write(bytes)
+
+    LibWebP.free(buffer)
   end
 
   private def check(code)

--- a/src/pluto/format/webp.cr
+++ b/src/pluto/format/webp.cr
@@ -1,6 +1,6 @@
 module Pluto::Format::WebP
   macro included
-    # This is the preferred, most performant JPEG overload with the least memory consumption.
+    # This is the preferred, most performant WebP overload with the least memory consumption.
     def self.from_webp(image_data : Bytes) : self
       check LibWebP.get_info(image_data, image_data.size, out width, out height)
       buffer = LibWebP.decode_rgba(
@@ -27,7 +27,7 @@ module Pluto::Format::WebP
       new(red, green, blue, alpha, width, height)
     end
 
-    # This is a less preferred JPEG overload.
+    # This is a less preferred WebP overload.
     def self.from_webp(io : IO) : self
       from_webp(io.getb_to_end)
     end

--- a/src/pluto/image.cr
+++ b/src/pluto/image.cr
@@ -6,6 +6,7 @@ abstract class Pluto::Image
   macro inherited
     include Format::JPEG
     include Format::PPM
+    include Format::WebP
 
     include Operation::BilinearResize
     include Operation::BoxBlur


### PR DESCRIPTION
Closes #17

For now, only with lossless RGBA support. If the need arises, we may consider adding additional features.

Docs:

- https://developers.google.com/speed/webp/docs/api
- https://developers.google.com/speed/webp/faq#what_color_spaces_does_the_webp_format_support
