### PR TITLE
Let libturbo-jpeg handle the buffer

### DIFF
--- a/src/pluto/bindings/lib_jpeg_turbo.cr
+++ b/src/pluto/bindings/lib_jpeg_turbo.cr
@@ -10,6 +10,7 @@ lib LibJPEGTurbo
   fun get_error_str = tjGetErrorStr2(handle : Handle) : UInt8*
   fun init_compress = tjInitCompress : Handle
   fun init_decompress = tjInitDecompress : Handle
+  fun free = tjFree(buffer : UInt8*) : Void
 
   enum Colorspace
     RGB

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -60,7 +60,7 @@ module Pluto::Format::JPEG
       image_data.write_byte(blue.unsafe_fetch(index))
     end
 
-    buffer = Array(UInt8).new.to_unsafe
+    buffer = Pointer(UInt8).null
     check handle, LibJPEGTurbo.compress2(
       handle,
       image_data.buffer,
@@ -78,6 +78,8 @@ module Pluto::Format::JPEG
 
     bytes = Bytes.new(buffer, size)
     io.write(bytes)
+
+    LibJPEGTurbo.free(buffer)
   end
 
   private def check(handle, code)


### PR DESCRIPTION
According to https://rawcdn.githack.com/libjpeg-turbo/libjpeg-turbo/2.1.x/doc/html/group___turbo_j_p_e_g.html#gafbdce0112fd78fd38efae841443a9bcf the buffer passed to compress2 should honor the following rules

> jpegBuf: address of a pointer to a byte buffer that will receive the JPEG image. TurboJPEG has the ability to reallocate the JPEG buffer to accommodate the size of the JPEG image. Thus, you can choose to:
>
>   -  pre-allocate the JPEG buffer with an arbitrary size using [tjAlloc()](https://rawcdn.githack.com/libjpeg-turbo/libjpeg-turbo/2.1.x/doc/html/group___turbo_j_p_e_g.html#gaec627dd4c5f30b7a775a7aea3bec5d83) and let TurboJPEG grow the buffer as needed,
>   -  set *jpegBuf to NULL to tell TurboJPEG to allocate the buffer for you, or
>   - pre-allocate the buffer to a "worst case" size determined by calling [tjBufSize()](https://rawcdn.githack.com/libjpeg-turbo/libjpeg-turbo/2.1.x/doc/html/group___turbo_j_p_e_g.html#ga67ac12fee79073242cb216e07c9f1f90). This should ensure that the buffer never has to be re-allocated. (Setting [TJFLAG_NOREALLOC](https://rawcdn.githack.com/libjpeg-turbo/libjpeg-turbo/2.1.x/doc/html/group___turbo_j_p_e_g.html#ga8808d403c68b62aaa58a4c1e58e98963) guarantees that it won't be.)
>
> If you choose option 1, then *jpegSize should be set to the size of your pre-allocated buffer. In any case, unless you have set [TJFLAG_NOREALLOC](https://rawcdn.githack.com/libjpeg-turbo/libjpeg-turbo/2.1.x/doc/html/group___turbo_j_p_e_g.html#ga8808d403c68b62aaa58a4c1e58e98963), you should always check *jpegBuf upon return from this function, as it may have changed.

Before this PR we are passing a pre-allocated buffer that depends on the default array size, which can be not enough. I Think the safer approach is to let libturbo-jpeg handle the buffer entierly, hence passing `NULL` as value. The buffer needs to be freed explicitly since it's not managed by the GC.

Another alternative, depending on performance needs is to have a preallocated buffer that is reused across multiple calls.

