### PR TITLE
Replace round with clamp

### DIFF
--- a/spec/pluto/operation/box_blur_spec.cr
+++ b/spec/pluto/operation/box_blur_spec.cr
@@ -7,7 +7,7 @@ describe Pluto::Operation::BoxBlur do
       blurred_image = image.box_blur(10)
 
       expect_digest image, "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
-      expect_digest blurred_image, "2a14473b3004d51de5c63397a4e4089bc2a3bf67"
+      expect_digest blurred_image, "dc18cddfd3486fa33dae3af028a9da3274facc3e"
     end
 
     it "works with ImageRGBA" do
@@ -15,7 +15,7 @@ describe Pluto::Operation::BoxBlur do
       blurred_image = image.box_blur(10)
 
       expect_digest image, "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
-      expect_digest blurred_image, "69360969157745b7fb63cf07ccbef3dd91e25f62"
+      expect_digest blurred_image, "df1710255ae9dbd5a86832546cfb6a23b558c9bb"
     end
   end
 
@@ -24,14 +24,14 @@ describe Pluto::Operation::BoxBlur do
       image = grayscale_sample
       image.box_blur!(10)
 
-      expect_digest image, "2a14473b3004d51de5c63397a4e4089bc2a3bf67"
+      expect_digest image, "dc18cddfd3486fa33dae3af028a9da3274facc3e"
     end
 
     it "works with ImageRGBA" do
       image = rgba_sample
       image.box_blur!(10)
 
-      expect_digest image, "69360969157745b7fb63cf07ccbef3dd91e25f62"
+      expect_digest image, "df1710255ae9dbd5a86832546cfb6a23b558c9bb"
     end
   end
 end

--- a/spec/pluto/operation/gaussian_blur_spec.cr
+++ b/spec/pluto/operation/gaussian_blur_spec.cr
@@ -7,7 +7,7 @@ describe Pluto::Operation::GaussianBlur do
       blurred_image = image.gaussian_blur(10)
 
       expect_digest image, "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
-      expect_digest blurred_image, "b1b30bdb0dc41f759ac74195349a3c3e3f88ac87"
+      expect_digest blurred_image, "df13de316f347c955309abcada06657d00b55bf5"
     end
 
     it "works with ImageRGBA" do
@@ -15,7 +15,7 @@ describe Pluto::Operation::GaussianBlur do
       blurred_image = image.gaussian_blur(10)
 
       expect_digest image, "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
-      expect_digest blurred_image, "05159a180871f9416c1fdb600a38c21f51bbcb6e"
+      expect_digest blurred_image, "245b54db2a7b075bf5404dc34d8b96357349f4d2"
     end
   end
 
@@ -24,14 +24,14 @@ describe Pluto::Operation::GaussianBlur do
       image = grayscale_sample
       image.gaussian_blur!(10)
 
-      expect_digest image, "b1b30bdb0dc41f759ac74195349a3c3e3f88ac87"
+      expect_digest image, "df13de316f347c955309abcada06657d00b55bf5"
     end
 
     it "works with ImageRGBA" do
       image = rgba_sample
       image.gaussian_blur!(10)
 
-      expect_digest image, "05159a180871f9416c1fdb600a38c21f51bbcb6e"
+      expect_digest image, "245b54db2a7b075bf5404dc34d8b96357349f4d2"
     end
   end
 end

--- a/spec/pluto/operation/horizontal_blur_spec.cr
+++ b/spec/pluto/operation/horizontal_blur_spec.cr
@@ -7,7 +7,7 @@ describe Pluto::Operation::HorizontalBlur do
       blurred_image = image.horizontal_blur(10)
 
       expect_digest image, "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
-      expect_digest blurred_image, "7d889ea6f8e71edf06024706774b6d430977a2ab"
+      expect_digest blurred_image, "b04348fe463d35197cc57b0114596d9b78a20f55"
     end
 
     it "works with ImageRGBA" do
@@ -15,13 +15,20 @@ describe Pluto::Operation::HorizontalBlur do
       blurred_image = image.horizontal_blur(10)
 
       expect_digest image, "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
-      expect_digest blurred_image, "3441fa29b711daddecb8df015d03a3ce40312011"
+      expect_digest blurred_image, "625be82cf07186fde56a81059c8149bc192bb1c9"
     end
 
     it "doesn't cause arithmetic overload" do
       with_sample("problem_images/28_arithmetic_overflow_in_blur.jpg") do |io|
         image = Pluto::ImageRGBA.from_jpeg(io)
-        expect_digest image.horizontal_blur(10), "20247bbe9560acdc857f59957c121d964ac09549"
+        expect_digest image.horizontal_blur(10), "5ddb10856f206d2a2eeb020e3e5b69657f5311bc"
+      end
+    end
+
+    it "doesn't cause arithmetic overload again" do
+      with_sample("problem_images/46_arithmetic_overflow_in_blur_again.jpg") do |io|
+        image = Pluto::ImageRGBA.from_jpeg(io)
+        expect_digest image.horizontal_blur(5), "9633b98682df51b71154a3792501ef72666b2dba"
       end
     end
   end
@@ -31,14 +38,14 @@ describe Pluto::Operation::HorizontalBlur do
       image = grayscale_sample
       image.horizontal_blur!(10)
 
-      expect_digest image, "7d889ea6f8e71edf06024706774b6d430977a2ab"
+      expect_digest image, "b04348fe463d35197cc57b0114596d9b78a20f55"
     end
 
     it "works with ImageRGBA" do
       image = rgba_sample
       image.horizontal_blur!(10)
 
-      expect_digest image, "3441fa29b711daddecb8df015d03a3ce40312011"
+      expect_digest image, "625be82cf07186fde56a81059c8149bc192bb1c9"
     end
   end
 end

--- a/spec/pluto/operation/vertical_blur_spec.cr
+++ b/spec/pluto/operation/vertical_blur_spec.cr
@@ -24,13 +24,6 @@ describe Pluto::Operation::VerticalBlur do
         expect_digest image.vertical_blur(10), "fd483aa927fb2ca8fdeb714e82dbbd3bf173daba"
       end
     end
-
-    it "doesn't cause arithmetic overload" do
-      with_sample("problem_images/46_arithmetic_overflow_in_blur_again.jpg") do |io|
-        image = Pluto::ImageRGBA.from_jpeg(io)
-        expect_digest image.vertical_blur(5), "89039df3a08bef9ba379263cedcfdc27cc8c891d"
-      end
-    end
   end
 
   describe "#vertical_blur!" do

--- a/spec/pluto/operation/vertical_blur_spec.cr
+++ b/spec/pluto/operation/vertical_blur_spec.cr
@@ -7,7 +7,7 @@ describe Pluto::Operation::VerticalBlur do
       blurred_image = image.vertical_blur(10)
 
       expect_digest image, "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
-      expect_digest blurred_image, "45b4a49232674ed4e33c06e09c19ba22e0baa3c3"
+      expect_digest blurred_image, "38d71a5c13f46afdca6b13ecbdeb97327cd46dd7"
     end
 
     it "works with ImageRGBA" do
@@ -15,13 +15,20 @@ describe Pluto::Operation::VerticalBlur do
       blurred_image = image.vertical_blur(10)
 
       expect_digest image, "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
-      expect_digest blurred_image, "d50bbaba05b5a42ccd1b3c8e14092b10075b07e9"
+      expect_digest blurred_image, "d7116d6cea0a14e23cc3a23dbc86ad8bf1fecf2f"
     end
 
     it "doesn't cause arithmetic overload" do
       with_sample("problem_images/28_arithmetic_overflow_in_blur.jpg") do |io|
         image = Pluto::ImageRGBA.from_jpeg(io)
-        expect_digest image.vertical_blur(10), "64039b39a57fc260bfd433d3fc298a8ac5366938"
+        expect_digest image.vertical_blur(10), "fd483aa927fb2ca8fdeb714e82dbbd3bf173daba"
+      end
+    end
+
+    it "doesn't cause arithmetic overload" do
+      with_sample("problem_images/46_arithmetic_overflow_in_blur_again.jpg") do |io|
+        image = Pluto::ImageRGBA.from_jpeg(io)
+        expect_digest image.vertical_blur(5), "89039df3a08bef9ba379263cedcfdc27cc8c891d"
       end
     end
   end
@@ -31,14 +38,14 @@ describe Pluto::Operation::VerticalBlur do
       image = grayscale_sample
       image.vertical_blur!(10)
 
-      expect_digest image, "45b4a49232674ed4e33c06e09c19ba22e0baa3c3"
+      expect_digest image, "38d71a5c13f46afdca6b13ecbdeb97327cd46dd7"
     end
 
     it "works with ImageRGBA" do
       image = rgba_sample
       image.vertical_blur!(10)
 
-      expect_digest image, "d50bbaba05b5a42ccd1b3c8e14092b10075b07e9"
+      expect_digest image, "d7116d6cea0a14e23cc3a23dbc86ad8bf1fecf2f"
     end
   end
 end

--- a/src/pluto/operation/horizontal_blur.cr
+++ b/src/pluto/operation/horizontal_blur.cr
@@ -23,7 +23,7 @@ module Pluto::Operation::HorizontalBlur
 
         (0..value).each do
           c_value += channel.unsafe_fetch(r_index).to_i - f_value
-          buffer.unsafe_put(c_index, (c_value * multiplier).round.to_u8)
+          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
 
           r_index += 1
           c_index += 1
@@ -31,7 +31,7 @@ module Pluto::Operation::HorizontalBlur
 
         (value + 1..@width - value - 1).each do
           c_value += (channel.unsafe_fetch(r_index).to_i - channel.unsafe_fetch(l_index).to_i)
-          buffer.unsafe_put(c_index, (c_value * multiplier).round.to_u8)
+          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
 
           r_index += 1
           l_index += 1
@@ -40,7 +40,7 @@ module Pluto::Operation::HorizontalBlur
 
         (@width - value..@width - 1).each do
           c_value += l_value - channel.unsafe_fetch(l_index).to_i
-          buffer.unsafe_put(c_index, (c_value * multiplier).round.to_u8)
+          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
 
           l_index += 1
           c_index += 1

--- a/src/pluto/operation/vertical_blur.cr
+++ b/src/pluto/operation/vertical_blur.cr
@@ -23,7 +23,7 @@ module Pluto::Operation::VerticalBlur
 
         (0..value).each do
           c_value += channel.unsafe_fetch(r_index).to_i - f_value
-          buffer.unsafe_put(c_index, (c_value * multiplier).round.to_u8)
+          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
 
           r_index += @width
           c_index += @width
@@ -31,7 +31,7 @@ module Pluto::Operation::VerticalBlur
 
         (value + 1..@height - value - 1).each do
           c_value += channel.unsafe_fetch(r_index).to_i - channel.unsafe_fetch(l_index).to_i
-          buffer.unsafe_put(c_index, (c_value * multiplier).round.to_u8)
+          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
 
           l_index += @width
           r_index += @width
@@ -40,7 +40,7 @@ module Pluto::Operation::VerticalBlur
 
         (@height - value..@height - 1).each do
           c_value += l_value - channel.unsafe_fetch(l_index).to_i
-          buffer.unsafe_put(c_index, (c_value * multiplier).round.to_u8)
+          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
 
           l_index += @width
           c_index += @width


### PR DESCRIPTION
Fixes #46 . The `round` -> `clamp` changed many of the digests back to what was seen prior to #33 (which initially added back the `round` method).