### PR TITLE
An alternative syntax for cropping

### DIFF
--- a/spec/pluto/operation/crop_spec.cr
+++ b/spec/pluto/operation/crop_spec.cr
@@ -26,6 +26,8 @@ describe Pluto::Operation::Crop do
       expect_digest image, "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
       expect_digest whole_image, "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
       expect_digest cropped_image, "42c223c282a5ca6419683e98216908520838b717"
+      expect_digest image[.., ..], "1a4d4e43e17f3245cefe5dd2c002fb85de079ae8"
+      expect_digest image[200...300, 200...300], "42c223c282a5ca6419683e98216908520838b717"
     end
 
     it "works with ImageRGBA" do
@@ -36,6 +38,8 @@ describe Pluto::Operation::Crop do
       expect_digest image, "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
       expect_digest whole_image, "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
       expect_digest cropped_image, "d02012cf3aae614ef06f1dbbf4aa8952905b259b"
+      expect_digest image[.., ..], "d7fa6faf6eec5350f8de8b41f478bf7e8d217fa9"
+      expect_digest image[200...300, 200...300], "d02012cf3aae614ef06f1dbbf4aa8952905b259b"
     end
   end
 

--- a/src/pluto/image.cr
+++ b/src/pluto/image.cr
@@ -33,4 +33,10 @@ abstract class Pluto::Image
   def size : Int32
     width * height
   end
+
+  private def resolve_to_start_and_count(range, size) : Tuple(Int32, Int32)
+    start, count = Indexable.range_to_index_and_count(range, size) || raise IndexError.new("Unable to resolve range #{range} for image dimension of #{size}")
+    raise IndexError.new("Range #{range} exceeds bounds of #{size}") if (start + count) > size
+    {start, count}
+  end
 end

--- a/src/pluto/operation/crop.cr
+++ b/src/pluto/operation/crop.cr
@@ -1,4 +1,10 @@
 module Pluto::Operation::Crop
+  def [](xrange : Range, yrange : Range) : self
+    xstart, xcount = resolve_to_start_and_count(xrange, width)
+    ystart, ycount = resolve_to_start_and_count(yrange, height)
+    crop(xstart, ystart, xcount, ycount)
+  end
+
   def crop(x : Int32, y : Int32, new_width : Int32, new_height : Int32) : self
     clone.crop!(x, y, new_width, new_height)
   end


### PR DESCRIPTION
This provides another syntax for cropping images that feels more idiomatic to crystal. 

```crystal
# These are equivalent
image.crop(20, 40, 100, 100)
image[20...120, 40...140]
```

Thoughts welcome!