### PR TITLE
Fix bug in horizontal and vertical blur causing arithmetic overflow

### DIFF
--- a/scripts/benchmark.cr
+++ b/scripts/benchmark.cr
@@ -1,6 +1,9 @@
 #!/usr/bin/env -S crystal run --no-debug --release
 
 require "../src/pluto"
+require "../src/pluto/format/jpeg"
+require "../src/pluto/format/png"
+require "../src/pluto/format/webp"
 
 record Result, name : String, time : Float64, memory : Int64
 
@@ -81,6 +84,7 @@ results << benchmark { image.crop!(200, 200, 100, 100) }
 results << benchmark { image.to_jpeg(IO::Memory.new) }
 results << benchmark { image.to_png(IO::Memory.new) }
 results << benchmark { image.to_ppm(IO::Memory.new) }
-results << benchmark { image.to_webp(IO::Memory.new) }
+results << benchmark { image.to_lossy_webp(IO::Memory.new) }
+results << benchmark { image.to_lossless_webp(IO::Memory.new) }
 
 print_result_table(results)

--- a/scripts/benchmark.cr
+++ b/scripts/benchmark.cr
@@ -1,9 +1,6 @@
 #!/usr/bin/env -S crystal run --no-debug --release
 
 require "../src/pluto"
-require "../src/pluto/format/jpeg"
-require "../src/pluto/format/png"
-require "../src/pluto/format/webp"
 
 record Result, name : String, time : Float64, memory : Int64
 
@@ -84,7 +81,6 @@ results << benchmark { image.crop!(200, 200, 100, 100) }
 results << benchmark { image.to_jpeg(IO::Memory.new) }
 results << benchmark { image.to_png(IO::Memory.new) }
 results << benchmark { image.to_ppm(IO::Memory.new) }
-results << benchmark { image.to_lossy_webp(IO::Memory.new) }
-results << benchmark { image.to_lossless_webp(IO::Memory.new) }
+results << benchmark { image.to_webp(IO::Memory.new) }
 
 print_result_table(results)

--- a/spec/pluto/operation/horizontal_blur_spec.cr
+++ b/spec/pluto/operation/horizontal_blur_spec.cr
@@ -21,14 +21,14 @@ describe Pluto::Operation::HorizontalBlur do
     it "doesn't cause arithmetic overload" do
       with_sample("problem_images/28_arithmetic_overflow_in_blur.jpeg") do |io|
         image = Pluto::ImageRGBA.from_jpeg(io)
-        expect_digest image.horizontal_blur(10), "5ddb10856f206d2a2eeb020e3e5b69657f5311bc"
+        expect_digest image.horizontal_blur(10), "d1e2b9363a2e7a36e738599cda8dab844a828b15"
       end
     end
 
     it "doesn't cause arithmetic overload again" do
       with_sample("problem_images/46_arithmetic_overflow_in_blur_again.jpeg") do |io|
         image = Pluto::ImageRGBA.from_jpeg(io)
-        expect_digest image.horizontal_blur(5), "9633b98682df51b71154a3792501ef72666b2dba"
+        expect_digest image.horizontal_blur(5), "a6ce6aeb78bc3cc6cff8e39f932b3e778b127950"
       end
     end
   end

--- a/spec/pluto/operation/vertical_blur_spec.cr
+++ b/spec/pluto/operation/vertical_blur_spec.cr
@@ -21,7 +21,7 @@ describe Pluto::Operation::VerticalBlur do
     it "doesn't cause arithmetic overload" do
       with_sample("problem_images/28_arithmetic_overflow_in_blur.jpeg") do |io|
         image = Pluto::ImageRGBA.from_jpeg(io)
-        expect_digest image.vertical_blur(10), "fd483aa927fb2ca8fdeb714e82dbbd3bf173daba"
+        expect_digest image.vertical_blur(10), "00e2c8a20e4554242bca3e0acf841028a2922fe6"
       end
     end
   end

--- a/src/pluto/operation/horizontal_blur.cr
+++ b/src/pluto/operation/horizontal_blur.cr
@@ -1,49 +1,50 @@
 module Pluto::Operation::HorizontalBlur
-  def horizontal_blur(value : Int32) : self
-    clone.horizontal_blur!(value)
+  def horizontal_blur(k : Int32) : self
+    clone.horizontal_blur!(k)
   end
 
-  def horizontal_blur!(value : Int32) : self
+  # Blur each row of the image using a sliding window that's `2k + 1` wide
+  def horizontal_blur!(k : Int32) : self
     buffer = Bytes.new(size, 0)
-    multiplier = 1 / (value + value + 1)
+    multiplier = 1 / (k + k + 1)
 
     each_channel do |channel|
       @height.times do |y|
-        c_index : Int32 = y * @width
-        l_index : Int32 = c_index
-        r_index : Int32 = c_index + value
+        row__offset : Int32 = y * @width
+        left__bound : Int32 = row__offset
+        right_bound : Int32 = row__offset + k
 
-        f_value : Int32 = channel.unsafe_fetch(c_index).to_i
-        l_value : Int32 = channel.unsafe_fetch(c_index + @width - 1).to_i
-        c_value : Int32 = (value + 1) * f_value
+        value_at_row_beginning : Int32 = channel.unsafe_fetch(row__offset).to_i
+        value_at_row_end : Int32 = channel.unsafe_fetch(row__offset + @width - 1).to_i
+        current_sum : Int32 = (k + 1) * value_at_row_beginning
 
-        (0..value - 1).each do
-          c_value += channel.unsafe_fetch(c_index)
+        (0..k - 1).each do |i|
+          current_sum += channel.unsafe_fetch(row__offset + i)
         end
 
-        (0..value).each do
-          c_value += channel.unsafe_fetch(r_index).to_i - f_value
-          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
+        (0..k).each do
+          current_sum += channel.unsafe_fetch(right_bound).to_i - value_at_row_beginning
+          buffer.unsafe_put(row__offset, (current_sum * multiplier).to_u8)
 
-          r_index += 1
-          c_index += 1
+          right_bound += 1
+          row__offset += 1
         end
 
-        (value + 1..@width - value - 1).each do
-          c_value += (channel.unsafe_fetch(r_index).to_i - channel.unsafe_fetch(l_index).to_i)
-          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
+        (k + 1..@width - k - 1).each do
+          current_sum += (channel.unsafe_fetch(right_bound).to_i - channel.unsafe_fetch(left__bound).to_i)
+          buffer.unsafe_put(row__offset, (current_sum * multiplier).to_u8)
 
-          r_index += 1
-          l_index += 1
-          c_index += 1
+          right_bound += 1
+          left__bound += 1
+          row__offset += 1
         end
 
-        (@width - value..@width - 1).each do
-          c_value += l_value - channel.unsafe_fetch(l_index).to_i
-          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
+        (@width - k..@width - 1).each do
+          current_sum += value_at_row_end - channel.unsafe_fetch(left__bound).to_i
+          buffer.unsafe_put(row__offset, (current_sum * multiplier).to_u8)
 
-          l_index += 1
-          c_index += 1
+          left__bound += 1
+          row__offset += 1
         end
       end
 

--- a/src/pluto/operation/horizontal_blur.cr
+++ b/src/pluto/operation/horizontal_blur.cr
@@ -1,50 +1,54 @@
 module Pluto::Operation::HorizontalBlur
-  def horizontal_blur(k : Int32) : self
-    clone.horizontal_blur!(k)
+  def horizontal_blur(value : Int32) : self
+    clone.horizontal_blur!(value)
   end
 
-  # Blur each row of the image using a sliding window that's `2k + 1` wide
-  def horizontal_blur!(k : Int32) : self
+  # boxBlurH_4 in Algorithm 4 in [this](https://blog.ivank.net/fastest-gaussian-blur.html) post.
+  #
+  # This is running a horizontal window that is `2 * value + 1` wide along each row and replacing the
+  # center pixel with sum of all pixels in the window multiplied by `1 / (2 * value + 1)` (i.e. the average
+  # of the pixels in the window).
+  def horizontal_blur!(value : Int32) : self
     buffer = Bytes.new(size, 0)
-    multiplier = 1 / (k + k + 1)
+    multiplier = 1 / (value + value + 1)
 
     each_channel do |channel|
       @height.times do |y|
-        row__offset : Int32 = y * @width
-        left__bound : Int32 = row__offset
-        right_bound : Int32 = row__offset + k
+        c_index : Int32 = y * @width
+        l_index : Int32 = c_index
+        r_index : Int32 = c_index + value
 
-        value_at_row_beginning : Int32 = channel.unsafe_fetch(row__offset).to_i
-        value_at_row_end : Int32 = channel.unsafe_fetch(row__offset + @width - 1).to_i
-        current_sum : Int32 = (k + 1) * value_at_row_beginning
+        f_value : Int32 = channel.unsafe_fetch(c_index).to_i
+        l_value : Int32 = channel.unsafe_fetch(c_index + @width - 1).to_i
+        c_value : Int32 = (value + 1) * f_value
 
-        (0..k - 1).each do |i|
-          current_sum += channel.unsafe_fetch(row__offset + i)
+        (0..value - 1).each do |i|
+          c_value += channel.unsafe_fetch(c_index + i)
         end
 
-        (0..k).each do
-          current_sum += channel.unsafe_fetch(right_bound).to_i - value_at_row_beginning
-          buffer.unsafe_put(row__offset, (current_sum * multiplier).to_u8)
+        (0..value).each do
+          c_value += channel.unsafe_fetch(r_index).to_i - f_value
+          buffer.unsafe_put(c_index, (c_value * multiplier).to_u8)
 
-          right_bound += 1
-          row__offset += 1
+          r_index += 1
+          c_index += 1
         end
 
-        (k + 1..@width - k - 1).each do
-          current_sum += (channel.unsafe_fetch(right_bound).to_i - channel.unsafe_fetch(left__bound).to_i)
-          buffer.unsafe_put(row__offset, (current_sum * multiplier).to_u8)
+        (value + 1..@width - value - 1).each do
+          c_value += (channel.unsafe_fetch(r_index).to_i - channel.unsafe_fetch(l_index).to_i)
+          buffer.unsafe_put(c_index, (c_value * multiplier).to_u8)
 
-          right_bound += 1
-          left__bound += 1
-          row__offset += 1
+          r_index += 1
+          l_index += 1
+          c_index += 1
         end
 
-        (@width - k..@width - 1).each do
-          current_sum += value_at_row_end - channel.unsafe_fetch(left__bound).to_i
-          buffer.unsafe_put(row__offset, (current_sum * multiplier).to_u8)
+        (@width - value..@width - 1).each do
+          c_value += l_value - channel.unsafe_fetch(l_index).to_i
+          buffer.unsafe_put(c_index, (c_value * multiplier).to_u8)
 
-          left__bound += 1
-          row__offset += 1
+          l_index += 1
+          c_index += 1
         end
       end
 

--- a/src/pluto/operation/vertical_blur.cr
+++ b/src/pluto/operation/vertical_blur.cr
@@ -1,49 +1,50 @@
 module Pluto::Operation::VerticalBlur
-  def vertical_blur(value : Int32) : self
-    clone.vertical_blur!(value)
+  def vertical_blur(k : Int32) : self
+    clone.vertical_blur!(k)
   end
 
-  def vertical_blur!(value : Int32) : self
+  # Blur each column of the image using a sliding window that's `2k + 1` tall
+  def vertical_blur!(k : Int32) : self
     buffer = Bytes.new(size, 0)
-    multiplier = 1 / (value + value + 1)
+    multiplier = 1 / (k + k + 1)
 
     each_channel do |channel|
       @width.times do |x|
-        c_index : Int32 = x
-        l_index : Int32 = c_index
-        r_index : Int32 = c_index + value * @width
+        col__offset : Int32 = x
+        upper_bound : Int32 = col__offset
+        lower_bound : Int32 = col__offset + k * @width
 
-        f_value : Int32 = channel.unsafe_fetch(c_index).to_i
-        l_value : Int32 = channel.unsafe_fetch(c_index + @width * (@height - 1)).to_i
-        c_value : Int32 = (value + 1) * f_value
+        value_at_top : Int32 = channel.unsafe_fetch(col__offset).to_i
+        value_at_bottom : Int32 = channel.unsafe_fetch(col__offset + @width * (@height - 1)).to_i
+        current_sum : Int32 = (k + 1) * value_at_top
 
-        (0..value - 1).each do
-          c_value += channel.unsafe_fetch(c_index)
+        (0..k - 1).each do |i|
+          current_sum += channel.unsafe_fetch(col__offset + i * @width)
         end
 
-        (0..value).each do
-          c_value += channel.unsafe_fetch(r_index).to_i - f_value
-          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
+        (0..k).each do
+          current_sum += channel.unsafe_fetch(lower_bound).to_i - value_at_top
+          buffer.unsafe_put(col__offset, (current_sum * multiplier).to_u8)
 
-          r_index += @width
-          c_index += @width
+          lower_bound += @width
+          col__offset += @width
         end
 
-        (value + 1..@height - value - 1).each do
-          c_value += channel.unsafe_fetch(r_index).to_i - channel.unsafe_fetch(l_index).to_i
-          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
+        (k + 1..@height - k - 1).each do
+          current_sum += channel.unsafe_fetch(lower_bound).to_i - channel.unsafe_fetch(upper_bound).to_i
+          buffer.unsafe_put(col__offset, (current_sum * multiplier).to_u8)
 
-          l_index += @width
-          r_index += @width
-          c_index += @width
+          upper_bound += @width
+          lower_bound += @width
+          col__offset += @width
         end
 
-        (@height - value..@height - 1).each do
-          c_value += l_value - channel.unsafe_fetch(l_index).to_i
-          buffer.unsafe_put(c_index, (c_value * multiplier).clamp(0, 255).to_u8)
+        (@height - k..@height - 1).each do
+          current_sum += value_at_bottom - channel.unsafe_fetch(upper_bound).to_i
+          buffer.unsafe_put(col__offset, (current_sum * multiplier).to_u8)
 
-          l_index += @width
-          c_index += @width
+          upper_bound += @width
+          col__offset += @width
         end
       end
 


### PR DESCRIPTION
Using definitions of `boxBlurH_4` and `boxBlurT_4` in **Algorithm 4** [here](https://blog.ivank.net/fastest-gaussian-blur.html) for guidance, noticed a missing term (pointed out below). 