### PR TITLE
Protect delegated `check_*` methods

### DIFF
--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -85,7 +85,9 @@ module Pluto::Format::JPEG
     Format::Binding::LibJPEGTurbo.free(buffer)
   end
 
-  protected delegate check_jpeg, to: self.class
+  # :nodoc:
+  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  delegate check_jpeg, to: self.class
 end
 
 {% for subclass in Pluto::Image.subclasses %}

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -85,7 +85,7 @@ module Pluto::Format::JPEG
     Format::Binding::LibJPEGTurbo.free(buffer)
   end
 
-  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly.")]
   # :nodoc:
   delegate check_jpeg, to: self.class
 end

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -85,7 +85,7 @@ module Pluto::Format::JPEG
     Format::Binding::LibJPEGTurbo.free(buffer)
   end
 
-  delegate check_jpeg, to: self.class
+  protected delegate check_jpeg, to: self.class
 end
 
 {% for subclass in Pluto::Image.subclasses %}

--- a/src/pluto/format/jpeg.cr
+++ b/src/pluto/format/jpeg.cr
@@ -85,8 +85,8 @@ module Pluto::Format::JPEG
     Format::Binding::LibJPEGTurbo.free(buffer)
   end
 
-  # :nodoc:
   @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  # :nodoc:
   delegate check_jpeg, to: self.class
 end
 

--- a/src/pluto/format/png.cr
+++ b/src/pluto/format/png.cr
@@ -91,7 +91,9 @@ module Pluto::Format::PNG
     LibC.free(buffer)
   end
 
-  protected delegate check_png, to: self.class
+  # :nodoc:
+  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  delegate check_png, to: self.class
 end
 
 {% for subclass in Pluto::Image.subclasses %}

--- a/src/pluto/format/png.cr
+++ b/src/pluto/format/png.cr
@@ -91,7 +91,7 @@ module Pluto::Format::PNG
     LibC.free(buffer)
   end
 
-  delegate check_png, to: self.class
+  protected delegate check_png, to: self.class
 end
 
 {% for subclass in Pluto::Image.subclasses %}

--- a/src/pluto/format/png.cr
+++ b/src/pluto/format/png.cr
@@ -91,8 +91,8 @@ module Pluto::Format::PNG
     LibC.free(buffer)
   end
 
-  # :nodoc:
   @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  # :nodoc:
   delegate check_png, to: self.class
 end
 

--- a/src/pluto/format/png.cr
+++ b/src/pluto/format/png.cr
@@ -91,7 +91,7 @@ module Pluto::Format::PNG
     LibC.free(buffer)
   end
 
-  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly.")]
   # :nodoc:
   delegate check_png, to: self.class
 end

--- a/src/pluto/format/webp.cr
+++ b/src/pluto/format/webp.cr
@@ -87,7 +87,9 @@ module Pluto::Format::WebP
     Format::Binding::LibWebP.free(buffer)
   end
 
-  protected delegate check_webp, to: self.class
+  # :nodoc:
+  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  delegate check_webp, to: self.class
 end
 
 {% for subclass in Pluto::Image.subclasses %}

--- a/src/pluto/format/webp.cr
+++ b/src/pluto/format/webp.cr
@@ -87,7 +87,7 @@ module Pluto::Format::WebP
     Format::Binding::LibWebP.free(buffer)
   end
 
-  delegate check_webp, to: self.class
+  protected delegate check_webp, to: self.class
 end
 
 {% for subclass in Pluto::Image.subclasses %}

--- a/src/pluto/format/webp.cr
+++ b/src/pluto/format/webp.cr
@@ -87,7 +87,7 @@ module Pluto::Format::WebP
     Format::Binding::LibWebP.free(buffer)
   end
 
-  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly.")]
   # :nodoc:
   delegate check_webp, to: self.class
 end

--- a/src/pluto/format/webp.cr
+++ b/src/pluto/format/webp.cr
@@ -87,8 +87,8 @@ module Pluto::Format::WebP
     Format::Binding::LibWebP.free(buffer)
   end
 
-  # :nodoc:
   @[Deprecated("The visibility of this method will be changing in the future, and it should not be used directly")]
+  # :nodoc:
   delegate check_webp, to: self.class
 end
 


### PR DESCRIPTION
I noticed these weren't private when playing with [CrystalDoc.info](https://crystaldoc.info/github/phenopolis/pluto/v1.0.1/Pluto/Format/JPEG.html#check_jpeg%28%2Aargs%2C%2A%2Aoptions%29-instance-method).

This is indeed a breaking change, so the next release will have to be 2.0.0.