### PR TITLE
Update `AUTHORS.md`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,21 @@
-# Contributors
+# Authors
 
-    2022.08.31 - Andrei Zhigalkin - creator, maintainer
-    2022.12.01 - Zac Nowicki
-    2023.02.05 - Troy Sornson - maintainer
-    2023.02.22 - Brian J. Cardiff
-    2023.04.12 - Serdar Dogruyol
+## Active maintainers
+
+| 1st contributed at | Name         |
+| ------------------ | ------------ |
+| 2023-02-05         | Troy Sornson |
+
+## Retired maintainers
+
+| 1st contributed at | Name             |
+| ------------------ | ---------------- |
+| 2022-08-31         | Andrei Zhigalkin |
+
+## Contributors
+
+| 1st contributed at | Name             |
+| ------------------ | ---------------- |
+| 2022-12-01         | Zac Nowicki      |
+| 2023-02-22         | Brian J. Cardiff |
+| 2023-04-12         | Serdar Dogruyol  |


### PR DESCRIPTION
I have updated the formatting of `AUTHORS.md` to improve the look and adjusted the dates to follow ISO 8601.

Additionally, I've placed myself in the retired maintainers category for the following reasons:

1. I’m no longer at Phenopolis, where this library is used in an internal project.
2. I’m not currently using it in personal projects.

Given the context, might be worthwhile merging this project with <https://github.com/Vici37/cr-image>?